### PR TITLE
Count is no longer printed out to stderr

### DIFF
--- a/docs/source/manpage.rst
+++ b/docs/source/manpage.rst
@@ -37,8 +37,8 @@ All options available as of Flake8 3.1.0::
                           verbosity each time it is repeated.
     -q, --quiet           Report only file names, or nothing. This option is
                           repeatable.
-    --count               Print total number of errors and warnings to standard
-                          error and set the exit code to 1 if total is not
+    --count               Print total number of errors and warnings
+                          and set the exit code to 1 if total is not
                           empty.
     --diff                Report changes only within line number ranges in the
                           unified diff provided on standard in by the user.

--- a/src/flake8/main/options.py
+++ b/src/flake8/main/options.py
@@ -52,7 +52,7 @@ def register_default_options(option_manager):
 
     add_option(
         '--count', action='store_true', parse_from_config=True,
-        help='Print total number of errors and warnings to standard error and'
+        help='Print total number of errors and warnings and'
              ' set the exit code to 1 if total is not empty.',
     )
 


### PR DESCRIPTION
Printing out count to stderr was removed in 3.0.0 https://github.com/PyCQA/flake8/blob/52180995046583cacf9d78a4423b82448a47fef1/docs/source/release-notes/3.0.0.rst