### PR TITLE
Use dash-seperated name for PYPI package

### DIFF
--- a/docs/source/plugin-development/registering-plugins.rst
+++ b/docs/source/plugin-development/registering-plugins.rst
@@ -34,13 +34,13 @@ like:
     flake8_entry_point = # ...
 
     setuptools.setup(
-        name="flake8_example",
+        name="flake8-example",
         license="MIT",
         version="0.1.0",
         description="our extension to flake8",
         author="Me",
         author_email="example@example.com",
-        url="https://gitlab.com/me/flake8_example",
+        url="https://gitlab.com/me/flake8-example",
         packages=[
             "flake8_example",
         ],


### PR DESCRIPTION
The name of the package will be normalized by `setuptools` anyway
and it will most likely appear as dash-separated on PYPI.[1]

This change also helps to keep the distinction between the PYPI
package name  and regular python packages (the directories with
__init__.py files).

[1]: https://mail.python.org/pipermail/distutils-sig/2011-August/017936.html