### PR TITLE
enable pip cache in appveyor build

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -4,5 +4,8 @@ install:
 
 build: off
 
+cache:
+  - '%LOCALAPPDATA%\pip\Cache'
+
 test_script:
   - python -m tox -e py27,py34,py35,dogfood


### PR DESCRIPTION
The reason for this pull request is the same reason caching was added to pip: we want to minimze the amount of traffic and load on the pypi site. Downloading any package(s) from pypi more than once is a waste of resources.