### PR TITLE
Fix invocation documentation

### DIFF
--- a/docs/source/user/invocation.rst
+++ b/docs/source/user/invocation.rst
@@ -119,7 +119,7 @@ And you should see something like:
                             errors on lines with "# noqa" at the end.
       --show-source         Show the source generate each error or warning.
       --statistics          Count errors and warnings.
-      --enabled-extensions=ENABLED_EXTENSIONS
+      --enable-extensions=ENABLED_EXTENSIONS
                             Enable plugins and extensions that are otherwise
                             disabled by default
       --exit-zero           Exit with status code "0" even if there are errors.


### PR DESCRIPTION
--enabled-extensions -> --enable-extensions

Maybe this should be generated for the argparse using some of the available sphinx module for this purpose to avoid such errors in the future?