### PR TITLE
Add --prepend-config command line option

### DIFF
--- a/docs/source/manpage.rst
+++ b/docs/source/manpage.rst
@@ -80,6 +80,11 @@ All options available as of Flake8 3.1.0::
     --output-file=OUTPUT_FILE
                           Redirect report to a file.
     --tee                 Write to stdout and output-file.
+    --prepend-config=PREPEND_CONFIG
+                          Provide extra config files to parse in addition to the
+                          files found by Flake8 by default. These files are the
+                          first ones read and so they take the lowest precedence
+                          when multiple files provide the same option.
     --append-config=APPEND_CONFIG
                           Provide extra config files to parse in addition to the
                           files found by Flake8 by default. These files are the

--- a/docs/source/user/invocation.rst
+++ b/docs/source/user/invocation.rst
@@ -130,6 +130,11 @@ And you should see something like:
       --output-file=OUTPUT_FILE
                             Redirect report to a file.
       --tee                 Write to stdout and output-file.
+      --prepend-config=PREPEND_CONFIG
+                            Provide extra config files to parse in addition to the
+                            files found by Flake8 by default. These files are the
+                            first ones read and so they take the lowest precedence
+                            when multiple files provide the same option.
       --append-config=APPEND_CONFIG
                             Provide extra config files to parse in addition to the
                             files found by Flake8 by default. These files are the

--- a/docs/source/user/options.rst
+++ b/docs/source/user/options.rst
@@ -80,6 +80,8 @@ Index of Options
 
 - :option:`flake8 --tee`
 
+- :option:`flake8 --prepend-config`
+
 - :option:`flake8 --append-config`
 
 - :option:`flake8 --config`
@@ -737,6 +739,27 @@ Options and their Descriptions
 
         output-file = output.txt
         tee = True
+
+
+.. option:: --prepend-config=<config>
+
+    :ref:`Go back to index <top>`
+
+    Provide extra config files to parse in before and in addition to the files
+    that |Flake8| found on its own. Since these files are the first ones read
+    into the Configuration Parser, they have the lowest precedence if it
+    provides an option specified in another config file.
+
+    Typical use is to specify cross-project options that can still be
+    overridden by user or project config files.
+
+    Command-line example:
+
+    .. prompt:: bash
+
+        flake8 --prepend-config=my-default-config.ini dir/
+
+    This **can not** be specified in config files.
 
 
 .. option:: --append-config=<config>

--- a/src/flake8/main/application.py
+++ b/src/flake8/main/application.py
@@ -152,11 +152,14 @@ class Application(object):
     def make_config_finder(self):
         """Make our ConfigFileFinder based on preliminary opts and args."""
         if self.config_finder is None:
+            prepend_config_files = utils.normalize_paths(
+                self.prelim_opts.prepend_config)
             extra_config_files = utils.normalize_paths(
                 self.prelim_opts.append_config)
             self.config_finder = config.ConfigFileFinder(
                 self.option_manager.program_name,
                 self.prelim_args,
+                prepend_config_files,
                 extra_config_files,
             )
 

--- a/src/flake8/main/options.py
+++ b/src/flake8/main/options.py
@@ -191,6 +191,14 @@ def register_default_options(option_manager):
     # Config file options
 
     add_option(
+        '--prepend-config', action='append',
+        help='Provide extra config files to parse in addition to the files '
+             'found by Flake8 by default. These files are the first ones read '
+             'and so they take the lowest precedence when multiple files '
+             'provide the same option.',
+    )
+
+    add_option(
         '--append-config', action='append',
         help='Provide extra config files to parse in addition to the files '
              'found by Flake8 by default. These files are the last ones read '

--- a/tests/fixtures/config_files/append-config.ini
+++ b/tests/fixtures/config_files/append-config.ini
@@ -1,0 +1,3 @@
+[flake8]
+select = W,F
+max-line-length = 80

--- a/tests/fixtures/config_files/prepend-config.ini
+++ b/tests/fixtures/config_files/prepend-config.ini
@@ -1,0 +1,3 @@
+[flake8]
+select = E,W
+max-line-length = 78

--- a/tests/integration/test_aggregator.py
+++ b/tests/integration/test_aggregator.py
@@ -26,7 +26,7 @@ def test_aggregate_options_with_config(optmanager):
     """Verify we aggregate options and config values appropriately."""
     arguments = ['flake8', '--config', CLI_SPECIFIED_CONFIG, '--select',
                  'E11,E34,E402,W,F', '--exclude', 'tests/*']
-    config_finder = config.ConfigFileFinder('flake8', arguments, [])
+    config_finder = config.ConfigFileFinder('flake8', arguments, [], [])
     options, args = aggregator.aggregate_options(
         optmanager, config_finder, arguments)
 
@@ -40,7 +40,7 @@ def test_aggregate_options_when_isolated(optmanager):
     """Verify we aggregate options and config values appropriately."""
     arguments = ['flake8', '--isolated', '--select', 'E11,E34,E402,W,F',
                  '--exclude', 'tests/*']
-    config_finder = config.ConfigFileFinder('flake8', arguments, [])
+    config_finder = config.ConfigFileFinder('flake8', arguments, [], [])
     optmanager.extend_default_ignore(['E8'])
     options, args = aggregator.aggregate_options(
         optmanager, config_finder, arguments)

--- a/tests/integration/test_aggregator.py
+++ b/tests/integration/test_aggregator.py
@@ -14,6 +14,8 @@ CLI_SPECIFIED_CONFIG = 'tests/fixtures/config_files/cli-specified.ini'
 USER_CONFIG = 'tests/fixtures/config_files/user-config.ini'
 LOCAL_CONFIG = 'tests/fixtures/config_files/local-config.ini'
 MISSING_CONFIG = 'tests/fixtures/config_files/missing.ini'
+PREPEND_CONFIG = 'tests/fixtures/config_files/prepend-config.ini'
+APPEND_CONFIG = 'tests/fixtures/config_files/append-config.ini'
 
 
 @pytest.fixture
@@ -72,6 +74,56 @@ def mock_config_finder(program='flake8', arguments=[],
         "select": {'E', 'W', 'F', 'C90'},
         "ignore": set(defaults.IGNORE),
         "max_line_length": 79,
+    }),
+    # Correct values with prepend config only
+    ({'prepend_configs': [PREPEND_CONFIG]}, {
+        "select": {'E', 'W'},
+        "ignore": set(defaults.IGNORE),
+        "max_line_length": 78,
+    }),
+    # Correct values with append config only
+    ({'append_configs': [APPEND_CONFIG]}, {
+        "select": {'W', 'F'},
+        "ignore": set(defaults.IGNORE),
+        "max_line_length": 80,
+    }),
+    # Correct values with user and prepend configs
+    ({
+        'user_config': USER_CONFIG,
+        'prepend_configs': [PREPEND_CONFIG]
+    }, {
+        "select": {'E', 'W'},
+        "ignore": ['D203'],
+        "max_line_length": 78,
+    }),
+    # Correct values with prepend and local configs
+    ({
+        'prepend_configs': [PREPEND_CONFIG],
+        'local_configs': [LOCAL_CONFIG]
+    }, {
+        "select": {'E', 'W', 'F'},
+        "ignore": set(defaults.IGNORE),
+        "max_line_length": 78,
+    }),
+    # Correct values with prepend and append configs
+    ({
+        'prepend_configs': [PREPEND_CONFIG],
+        'append_configs': [APPEND_CONFIG]
+    }, {
+        "select": {'W', 'F'},
+        "ignore": set(defaults.IGNORE),
+        "max_line_length": 80,
+    }),
+    # Correct values with user, append, local and prepend configs
+    ({
+        'user_config': USER_CONFIG,
+        'prepend_configs': [PREPEND_CONFIG],
+        'local_configs': [LOCAL_CONFIG],
+        'append_configs': [APPEND_CONFIG],
+    }, {
+        "select": {'W', 'F'},
+        "ignore": ['D203'],
+        "max_line_length": 80,
     }),
 ])
 def test_aggregate_options_resulting_values(

--- a/tests/unit/test_get_local_plugins.py
+++ b/tests/unit/test_get_local_plugins.py
@@ -31,7 +31,7 @@ def test_get_local_plugins_uses_cli_config():
 def test_get_local_plugins():
     """Verify get_local_plugins returns expected plugins."""
     config_fixture_path = 'tests/fixtures/config_files/local-plugin.ini'
-    config_finder = config.ConfigFileFinder('flake8', [], [])
+    config_finder = config.ConfigFileFinder('flake8', [], [], [])
 
     with mock.patch.object(config_finder, 'local_config_files') as localcfs:
         localcfs.return_value = [config_fixture_path]

--- a/tests/unit/test_merged_config_parser.py
+++ b/tests/unit/test_merged_config_parser.py
@@ -17,7 +17,7 @@ def optmanager():
 @pytest.fixture
 def config_finder():
     """Generate a simple ConfigFileFinder."""
-    return config.ConfigFileFinder('flake8', [], [])
+    return config.ConfigFileFinder('flake8', [], [], [])
 
 
 def test_parse_cli_config(optmanager, config_finder):


### PR DESCRIPTION
Add code to handle config files specified with the --prepend-config
argument.

Options specified in prepend files get a higher precedence than flake8
defaults but a lower one than user configs. This allows to override
the defaults without affecting the behaviour of user and local config
files.

This implements a solution for issue #349