### PR TITLE
Enable py37 check in TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,9 +20,10 @@ matrix:
       env: TOXENV=py35
     - python: 3.6
       env: TOXENV=py36
-    # https://github.com/travis-ci/travis-ci/issues/9069
-    #- python: 3.7
-    #  env: TOXENV=py37
+    - python: 3.7
+      env: TOXENV=py37
+      dist: xenial
+      sudo: true
     - python: pypy
       env: TOXENV=pypy
     - python: 2.7


### PR DESCRIPTION
There is workaround for python 3.7 in TravisCI form original issue: https://github.com/travis-ci/travis-ci/issues/9069#issuecomment-425720905