### PR TITLE
Move flake8 config from tox.ini to setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -16,3 +16,27 @@ requires-dist =
     pyflakes >= 2.0.0, < 2.1.0
     pycodestyle >= 2.4.0, < 2.5.0
     mccabe >= 0.6.0, < 0.7.0
+
+[flake8]
+# Ignore some flake8-docstrings errors
+# NOTE(sigmavirus24): While we're still using flake8 2.x, this ignore line
+# defaults to selecting all other errors so we do not need select=E,F,W,I,D
+# Once Flake8 3.0 is released and in a good state, we can use both and it will
+# work well \o/
+ignore = D203, W503, E203
+exclude =
+    .tox,
+    .git,
+    __pycache__,
+    docs/source/conf.py,
+    build,
+    dist,
+    tests/fixtures/*,
+    *.pyc,
+    *.egg-info,
+    .cache,
+    .eggs
+max-complexity = 10
+import-order-style = google
+application-import-names = flake8
+format = ${cyan}%(path)s${reset}:${yellow_bold}%(row)d${reset}:${green_bold}%(col)d${reset}: ${red_bold}%(code)s${reset} %(text)s

--- a/tox.ini
+++ b/tox.ini
@@ -147,28 +147,3 @@ deps =
 commands =
     {[testenv:build]commands}
     twine upload --skip-existing dist/*
-
-# Flake8 Configuration
-[flake8]
-# Ignore some flake8-docstrings errors
-# NOTE(sigmavirus24): While we're still using flake8 2.x, this ignore line
-# defaults to selecting all other errors so we do not need select=E,F,W,I,D
-# Once Flake8 3.0 is released and in a good state, we can use both and it will
-# work well \o/
-ignore = D203, W503, E203
-exclude =
-    .tox,
-    .git,
-    __pycache__,
-    docs/source/conf.py,
-    build,
-    dist,
-    tests/fixtures/*,
-    *.pyc,
-    *.egg-info,
-    .cache,
-    .eggs
-max-complexity = 10
-import-order-style = google
-application-import-names = flake8
-format = ${cyan}%(path)s${reset}:${yellow_bold}%(row)d${reset}:${green_bold}%(col)d${reset}: ${red_bold}%(code)s${reset} %(text)s


### PR DESCRIPTION
I was debugging some E203 issue, and then it took me some time to figure
out where flake8's own config would be - `tox.ini` is specific to tox in
general, and `setup.cfg` is a more canonical place.