### PR TITLE
Fixes handling of empty lists by Application

### DIFF
--- a/src/flake8/main/application.py
+++ b/src/flake8/main/application.py
@@ -122,7 +122,7 @@ class Application(object):
         # do not need to worry and we can continue. If it is, we successfully
         # defer printing the version until just a little bit later.
         # Similarly we have to defer printing the help text until later.
-        args = (argv or sys.argv)[:]
+        args = (argv if argv is not None else sys.argv)[:]
         try:
             args.remove("--version")
         except ValueError:

--- a/tests/unit/test_application.py
+++ b/tests/unit/test_application.py
@@ -1,5 +1,6 @@
 """Tests for the Application class."""
 import optparse
+import sys
 
 import mock
 import pytest
@@ -97,3 +98,12 @@ def test_prelim_opts_args(application):
     assert application.prelim_opts.statistics
     assert application.prelim_opts.verbose
     assert application.prelim_args == ['src', 'setup.py']
+
+
+def test_prelim_opts_handles_empty(application):
+    """Verify empty argv lists are handled correctly."""
+    irrelevant_args = ['myexe', '/path/to/foo']
+    with mock.patch.object(sys, 'argv', irrelevant_args):
+        application.parse_preliminary_options_and_args([])
+
+        assert application.prelim_args != irrelevant_args

--- a/tests/unit/test_application.py
+++ b/tests/unit/test_application.py
@@ -106,4 +106,4 @@ def test_prelim_opts_handles_empty(application):
     with mock.patch.object(sys, 'argv', irrelevant_args):
         application.parse_preliminary_options_and_args([])
 
-        assert application.prelim_args != irrelevant_args
+        assert application.prelim_args == []


### PR DESCRIPTION
`Application.parse_preliminary_options_and_args` was previously, against
expectations, treating empty lists passed as the `argv` argument the
same way it treated `None`s.

This has been addressed and the correct behavior tested for in a unit
test of the `Application` class.

See issue #518 for details.