### PR TITLE
Print errors to stderr

### DIFF
--- a/src/flake8/main/application.py
+++ b/src/flake8/main/application.py
@@ -394,8 +394,8 @@ class Application(object):
             LOG.exception(exc)
             self.catastrophic_failure = True
         except exceptions.ExecutionError as exc:
-            print("There was a critical error during execution of Flake8:")
-            print(exc)
+            print("There was a critical error during execution of Flake8:", file=sys.stderr)
+            print(exc, file=sys.stderr)
             LOG.exception(exc)
             self.catastrophic_failure = True
         except exceptions.EarlyQuit:


### PR DESCRIPTION
E.g.

    There was a critical error during execution of Flake8:
    Expected `per-file-ignores` to be a mapping from file exclude patterns to ignore codes.

    Configured `per-file-ignores` setting:

        …