### PR TITLE
Docs: Fix term link

### DIFF
--- a/docs/source/glossary.rst
+++ b/docs/source/glossary.rst
@@ -54,4 +54,4 @@
     mccabe
         The project |Flake8| depends on to calculate the McCabe complexity
         of a unit of code (e.g., a function). This uses the ``C``
-        :term:`class` of :term`error code`\ s.
+        :term:`class` of :term:`error code`\ s.


### PR DESCRIPTION
Compare with the working link under pycodestyle:

![image](https://user-images.githubusercontent.com/1324225/69723250-cbdbe400-1121-11ea-8bf5-78bb0d57888f.png)
