### PR TITLE
Fix wrong location reported for syntax errors

### DIFF
--- a/src/flake8/checker.py
+++ b/src/flake8/checker.py
@@ -580,8 +580,8 @@ class FileChecker:
         """Run checks against the file."""
         assert self.processor is not None
         try:
-            self.process_tokens()
             self.run_ast_checks()
+            self.process_tokens()
         except exceptions.InvalidSyntax as exc:
             self.report(
                 exc.error_code,

--- a/tests/integration/test_main.py
+++ b/tests/integration/test_main.py
@@ -1,6 +1,8 @@
 """Integration tests for the main entrypoint of flake8."""
 import json
 import os
+import platform
+import sys
 from unittest import mock
 
 import pytest
@@ -183,10 +185,17 @@ def test_tokenization_error_but_not_syntax_error(tmpdir, capsys):
         _call_main(['t.py'], retv=1)
 
     out, err = capsys.readouterr()
-    assert out == '''\
+
+    expected = '''\
 t.py:1:1: E902 TokenError: EOF in multi-line statement
-t.py:1:8: E999 SyntaxError: unexpected EOF while parsing
 '''
+
+    expected += '''\
+t.py:1:8: E999 SyntaxError: unexpected EOF while parsing
+''' if (platform.python_implementation() == "CPython"
+        and sys.version_info >= (3, 8)) else ""
+
+    assert out == expected
     assert err == ''
 
 

--- a/tests/integration/test_main.py
+++ b/tests/integration/test_main.py
@@ -183,7 +183,10 @@ def test_tokenization_error_but_not_syntax_error(tmpdir, capsys):
         _call_main(['t.py'], retv=1)
 
     out, err = capsys.readouterr()
-    assert out == 't.py:1:1: E902 TokenError: EOF in multi-line statement\n'
+    assert out == '''\
+t.py:1:1: E902 TokenError: EOF in multi-line statement
+t.py:1:8: E999 SyntaxError: unexpected EOF while parsing
+'''
     assert err == ''
 
 
@@ -194,7 +197,10 @@ def test_tokenization_error_is_a_syntax_error(tmpdir, capsys):
         _call_main(['t.py'], retv=1)
 
     out, err = capsys.readouterr()
-    assert out == 't.py:1:1: E902 IndentationError: unindent does not match any outer indentation level\n'  # noqa: E501
+    assert out == '''\
+t.py:1:1: E902 IndentationError: unindent does not match any outer indentation level
+t.py:3:5: E999 IndentationError: unindent does not match any outer indentation level
+'''  # noqa: E501
     assert err == ''
 
 


### PR DESCRIPTION
See #740

This solves the immediate problem of hiding relevant line numbers, by showing both E902 and E999. Admittedly it would be even better if only the E999 would show up in that case... I went for the 90% solution here though.

I did not provide new tests, but rather adapted the 2 existing tests to reflect the new (and desirable) behavior.