### PR TITLE
Add --extend-select command line argument

### DIFF
--- a/docs/source/user/invocation.rst
+++ b/docs/source/user/invocation.rst
@@ -115,6 +115,10 @@ And you should see something like:
                             run. (Default: 79)
       --select=errors       Comma-separated list of errors and warnings to enable.
                             For example, ``--select=E4,E51,W234``. (Default: )
+      --extend-select errors
+                            Comma-separated list of errors and warnings to add to
+                            the list of selected ones. For example, ``--extend-
+                            select=E4,E51,W234``.
       --disable-noqa        Disable the effect of "# noqa". This will report
                             errors on lines with "# noqa" at the end.
       --show-source         Show the source generate each error or warning.

--- a/docs/source/user/options.rst
+++ b/docs/source/user/options.rst
@@ -68,6 +68,8 @@ Index of Options
 
 - :option:`flake8 --select`
 
+- :option:`flake8 --extend-select`
+
 - :option:`flake8 --disable-noqa`
 
 - :option:`flake8 --show-source`
@@ -630,6 +632,38 @@ Options and their Descriptions
             E431,
             W,
             F
+
+
+.. option:: --extend-select=<errors>
+
+    :ref:`Go back to index <top>`
+
+    .. versionadded:: 4.0.0
+
+    Specify a list of codes to add to the list of selected ones. Similar
+    considerations as in :option:`--select` apply here with regard to the
+    value.
+
+    The difference to the :option:`--select` option is, that this option can be
+    used to selectively add individual codes without overriding the default
+    list entirely.
+
+    Command-line example:
+
+    .. prompt:: bash
+
+        flake8 --extend-select=E4,E51,W234 dir/
+
+    This **can** be specified in config files.
+
+    Example config file usage:
+
+    .. code-block:: ini
+
+        extend-select =
+            E4,
+            E51,
+            W234
 
 
 .. option:: --disable-noqa

--- a/src/flake8/main/options.py
+++ b/src/flake8/main/options.py
@@ -105,6 +105,7 @@ def register_default_options(option_manager):
     - ``--max-doc-length``
     - ``--indent-size``
     - ``--select``
+    - ``--extend-select``
     - ``--disable-noqa``
     - ``--show-source``
     - ``--statistics``
@@ -270,6 +271,18 @@ def register_default_options(option_manager):
         comma_separated_list=True,
         help="Comma-separated list of errors and warnings to enable."
         " For example, ``--select=E4,E51,W234``. (Default: %(default)s)",
+    )
+
+    add_option(
+        "--extend-select",
+        metavar="errors",
+        default="",
+        parse_from_config=True,
+        comma_separated_list=True,
+        help=(
+            "Comma-separated list of errors and warnings to add to the list "
+            "of selected ones. For example, ``--extend-select=E4,E51,W234``."
+        ),
     )
 
     add_option(

--- a/src/flake8/style_guide.py
+++ b/src/flake8/style_guide.py
@@ -162,7 +162,14 @@ class DecisionEngine:
         )
         self.enabled_extensions = tuple(options.enable_extensions)
         self.all_selected = tuple(
-            sorted(self.selected + self.enabled_extensions, reverse=True)
+            sorted(
+                itertools.chain(
+                    self.selected,
+                    options.extend_select,
+                    self.enabled_extensions,
+                ),
+                reverse=True,
+            )
         )
         self.ignored = tuple(
             sorted(

--- a/tests/unit/test_style_guide.py
+++ b/tests/unit/test_style_guide.py
@@ -14,6 +14,7 @@ def create_options(**kwargs):
     """Create and return an instance of argparse.Namespace."""
     kwargs.setdefault('select', [])
     kwargs.setdefault('extended_default_select', [])
+    kwargs.setdefault('extend_select', [])
     kwargs.setdefault('ignore', [])
     kwargs.setdefault('extend_ignore', [])
     kwargs.setdefault('disable_noqa', False)


### PR DESCRIPTION
Implement `--extend-select` command line argument following what was
done for `--extend-ignore` in !233 (see placeholder issue #1274). This option can be used to
selectively add individual codes without overriding the default list
entirely.

Addresses the remaining item of issue #1061.