### PR TITLE
Automatically create output directories

### DIFF
--- a/src/flake8/formatting/base.py
+++ b/src/flake8/formatting/base.py
@@ -1,5 +1,6 @@
 """The base class and interface for all formatting plugins."""
 import argparse
+import os
 from typing import IO
 from typing import List
 from typing import Optional
@@ -76,6 +77,8 @@ class BaseFormatter:
         This defaults to initializing :attr:`output_fd` if :attr:`filename`
         """
         if self.filename:
+            dirname = os.path.dirname(os.path.abspath(self.filename))
+            os.makedirs(dirname, exist_ok=True)
             self.output_fd = open(self.filename, "a")
 
     def handle(self, error: "Violation") -> None:

--- a/tests/integration/test_main.py
+++ b/tests/integration/test_main.py
@@ -343,10 +343,10 @@ def test_output_file(tmpdir, capsys):
     tmpdir.join("t.py").write("import os\n")
 
     with tmpdir.as_cwd():
-        _call_main(["t.py", "--output-file=f"], retv=1)
+        _call_main(["t.py", "--output-file=a/b/f"], retv=1)
 
     out, err = capsys.readouterr()
     assert out == err == ""
 
     expected = "t.py:1:1: F401 'os' imported but unused\n"
-    assert tmpdir.join("f").read() == expected
+    assert tmpdir.join("a/b/f").read() == expected


### PR DESCRIPTION
If the output file is on a non-existing path, we should create the missing components, just like is done in the handling of `--junit-xml=` in `pytest`.