### PR TITLE
Add support for reading config from pyproject.toml

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -42,6 +42,7 @@ install_requires=
     pycodestyle >= 2.7.0, < 2.8.0
     mccabe >= 0.6.0, < 0.7.0
     importlib-metadata; python_version<"3.8"
+    toml
 
 python_requires = >=3.6
 

--- a/src/flake8/options/config.py
+++ b/src/flake8/options/config.py
@@ -8,6 +8,7 @@ from typing import Optional
 from typing import Tuple
 
 import toml
+
 from flake8 import utils
 
 LOG = logging.getLogger(__name__)
@@ -53,7 +54,10 @@ class ConfigFileFinder:
 
         # List of filenames to find in the local/project directory
         self.project_filenames = (
-            "pyproject.toml", "setup.cfg", "tox.ini", f".{program_name}",
+            "pyproject.toml",
+            "setup.cfg",
+            "tox.ini",
+            f".{program_name}",
         )
 
         self.local_directory = os.path.abspath(os.curdir)

--- a/tests/fixtures/config_files/broken-pyproject.toml
+++ b/tests/fixtures/config_files/broken-pyproject.toml
@@ -1,0 +1,12 @@
+[tool.flake8]
+ignore = [
+    "E123",
+    "W234",
+    E111,
+]
+exclude = [
+    "foo/",
+    "bar/",
+    "bogus/",
+]
+quiet = 1

--- a/tests/fixtures/config_files/cli-specified-pyproject.toml
+++ b/tests/fixtures/config_files/cli-specified-pyproject.toml
@@ -1,0 +1,12 @@
+[tool.flake8]
+ignore = [
+    "E123",
+    "W234",
+    "E111",
+]
+exclude = [
+    "foo/",
+    "bar/",
+    "bogus/",
+]
+quiet = 1

--- a/tests/fixtures/config_files/no-flake8-section-pyproject.toml
+++ b/tests/fixtures/config_files/no-flake8-section-pyproject.toml
@@ -1,0 +1,12 @@
+[tool.flake9]
+ignore = [
+    "E123",
+    "W234",
+    "E111",
+]
+exclude = [
+    "foo/",
+    "bar/",
+    "bogus/",
+]
+quiet = 1

--- a/tests/unit/test_config_file_finder.py
+++ b/tests/unit/test_config_file_finder.py
@@ -10,8 +10,12 @@ from flake8.options import config
 CLI_SPECIFIED_FILEPATH = "tests/fixtures/config_files/cli-specified.ini"
 BROKEN_CONFIG_PATH = "tests/fixtures/config_files/broken.ini"
 
-CLI_SPECIFIED_PYPROJECT_CONFIG_PATH = "tests/fixtures/config_files/cli-specified-pyproject.toml"  # noqa: E501
-BROKEN_PYPROJECT_CONFIG_PATH = "tests/fixtures/config_files/broken-pyproject.toml"  # noqa: E501
+CLI_SPECIFIED_PYPROJECT_CONFIG_PATH = (
+    "tests/fixtures/config_files/cli-specified-pyproject.toml"  # noqa: E501
+)
+BROKEN_PYPROJECT_CONFIG_PATH = (
+    "tests/fixtures/config_files/broken-pyproject.toml"  # noqa: E501
+)
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_config_file_finder.py
+++ b/tests/unit/test_config_file_finder.py
@@ -10,10 +10,19 @@ from flake8.options import config
 CLI_SPECIFIED_FILEPATH = "tests/fixtures/config_files/cli-specified.ini"
 BROKEN_CONFIG_PATH = "tests/fixtures/config_files/broken.ini"
 
+CLI_SPECIFIED_PYPROJECT_CONFIG_PATH = "tests/fixtures/config_files/cli-specified-pyproject.toml"  # noqa: E501
+BROKEN_PYPROJECT_CONFIG_PATH = "tests/fixtures/config_files/broken-pyproject.toml"  # noqa: E501
 
-def test_cli_config():
+
+@pytest.mark.parametrize(
+    "cli_filepath",
+    [
+        CLI_SPECIFIED_FILEPATH,
+        CLI_SPECIFIED_PYPROJECT_CONFIG_PATH,
+    ],
+)
+def test_cli_config(cli_filepath):
     """Verify opening and reading the file specified via the cli."""
-    cli_filepath = CLI_SPECIFIED_FILEPATH
     finder = config.ConfigFileFinder("flake8")
 
     parsed_config = finder.cli_config(cli_filepath)
@@ -91,13 +100,19 @@ def test_local_configs():
     "files",
     [
         [BROKEN_CONFIG_PATH],
-        [CLI_SPECIFIED_FILEPATH, BROKEN_CONFIG_PATH],
+        [BROKEN_PYPROJECT_CONFIG_PATH],
+        [
+            CLI_SPECIFIED_FILEPATH,
+            BROKEN_CONFIG_PATH,
+            BROKEN_PYPROJECT_CONFIG_PATH,
+        ],
     ],
 )
 def test_read_config_catches_broken_config_files(files):
     """Verify that we do not allow the exception to bubble up."""
     _, parsed = config.ConfigFileFinder._read_config(*files)
     assert BROKEN_CONFIG_PATH not in parsed
+    assert BROKEN_PYPROJECT_CONFIG_PATH not in parsed
 
 
 def test_read_config_catches_decoding_errors(tmpdir):

--- a/tests/unit/test_merged_config_parser.py
+++ b/tests/unit/test_merged_config_parser.py
@@ -54,6 +54,7 @@ def test_parse_cli_config(optmanager, config_finder):
     [
         ("tests/fixtures/config_files/cli-specified.ini", True),
         ("tests/fixtures/config_files/no-flake8-section.ini", False),
+        ("tests/fixtures/config_files/no-flake8-section-pyproject.toml", False),  # noqa: E501
     ],
 )
 def test_is_configured_by(
@@ -188,6 +189,7 @@ def test_parse_uses_cli_config(optmanager):
         "tests/fixtures/config_files/cli-specified.ini",
         "tests/fixtures/config_files/cli-specified-with-inline-comments.ini",
         "tests/fixtures/config_files/cli-specified-without-inline-comments.ini",  # noqa: E501
+        "tests/fixtures/config_files/cli-specified-pyproject.toml",
     ],
 )
 def test_parsed_configs_are_equivalent(

--- a/tests/unit/test_merged_config_parser.py
+++ b/tests/unit/test_merged_config_parser.py
@@ -54,7 +54,10 @@ def test_parse_cli_config(optmanager, config_finder):
     [
         ("tests/fixtures/config_files/cli-specified.ini", True),
         ("tests/fixtures/config_files/no-flake8-section.ini", False),
-        ("tests/fixtures/config_files/no-flake8-section-pyproject.toml", False),  # noqa: E501
+        (
+            "tests/fixtures/config_files/no-flake8-section-pyproject.toml",
+            False,
+        ),  # noqa: E501
     ],
 )
 def test_is_configured_by(


### PR DESCRIPTION
With mypy support for `pyproject.toml` now merged (https://github.com/python/mypy/pull/10219), I think it would be good to try and add feature this to flake8 as well.

I have tried to implement this in a way to minimise pain, hopefully that's been achieved here.

Closes https://github.com/PyCQA/flake8/issues/234