### PR TITLE
Sort errors list in help

### DIFF
--- a/src/flake8/main/options.py
+++ b/src/flake8/main/options.py
@@ -207,7 +207,7 @@ def register_default_options(option_manager):
     add_option(
         "--ignore",
         metavar="errors",
-        default=",".join(defaults.IGNORE),
+        default=",".join(sorted(defaults.IGNORE)),
         parse_from_config=True,
         comma_separated_list=True,
         help="Comma-separated list of errors and warnings to ignore (or skip)."


### PR DESCRIPTION
[Mega-Linter](https://github.com/nvuillam/mega-linter) generates its help from flake8 --help

An automated job detects when there is a new version of help and triggers actions from this event
But as the list of returned errors is randomly ordered for every flake8 --help called, the result is never the same and there are false updates detection

Sorting the list of extensions will make help text to be always the same for the same version :)