### PR TITLE
Update default ignored errors

### DIFF
--- a/docs/source/user/invocation.rst
+++ b/docs/source/user/invocation.rst
@@ -106,7 +106,7 @@ And you should see something like:
                             of opening bracket's line.
       --ignore=errors       Comma-separated list of errors and warnings to ignore
                             (or skip). For example, ``--ignore=E4,E51,W234``.
-                            (Default: E121,E123,E126,E226,E24,E704)
+                            (Default: E121,E123,E126,E226,E24,E704,W503,W504)
       --extend-ignore=errors
                             Comma-separated list of errors and warnings to add to
                             the list of ignored ones. For example, ``--extend-


### PR DESCRIPTION
This new list should now reflect the default errors that are ignored as defined here:
https://github.com/PyCQA/flake8/blob/3bcadce2a9d91f4bb6afa97b5d2d1a82d7a1e937/src/flake8/defaults.py#L15