### PR TITLE
Improves plugin docs

### DIFF
--- a/docs/source/user/using-plugins.rst
+++ b/docs/source/user/using-plugins.rst
@@ -8,7 +8,7 @@ its extensibility. Our community has developed :term:`plugin`\ s that augment
 developers of these plugins often have some style they wish to enforce.
 
 For example, `flake8-docstrings`_ adds a check for :pep:`257` style
-conformance. Others attempt to enforce consistency, like `flake8-future`_.
+conformance. Others attempt to enforce consistency, like `flake8-quotes`_.
 
 .. note::
 
@@ -60,5 +60,5 @@ documented this for you.
     https://pypi.org/
 .. _flake8-docstrings:
     https://pypi.org/project/flake8-docstrings/
-.. _flake8-future:
-    https://pypi.org/project/flake8-future/
+.. _flake8-quotes:
+    https://pypi.org/project/flake8-quotes/


### PR DESCRIPTION
Replaces `flake8-future` with `flake8-quotes`

Why?

I was reading through the docs and I saw an interesting plugin which I was not aware of.
That's what I saw:
<img width="1280" alt="Снимок экрана 2021-06-22 в 12 13 53" src="https://user-images.githubusercontent.com/4660275/122898700-c3767a00-d353-11eb-9a7c-9547a81abfb3.png">
<img width="1280" alt="Снимок экрана 2021-06-22 в 12 13 41" src="https://user-images.githubusercontent.com/4660275/122898720-c6716a80-d353-11eb-89db-764cca74aea4.png">

This is clearly an outdated example, I have switched it to a more modern one.