### PR TITLE
Update --indent-size help format string

### DIFF
--- a/src/flake8/main/options.py
+++ b/src/flake8/main/options.py
@@ -260,7 +260,7 @@ def register_default_options(option_manager):
         metavar="n",
         default=defaults.INDENT_SIZE,
         parse_from_config=True,
-        help="Number of spaces used for indentation (Default: %default)",
+        help="Number of spaces used for indentation (Default: %(default)s)",
     )
 
     add_option(


### PR DESCRIPTION
Fixes this warning:
```
WARNING  flake8.options.manager:manager.py:186 option --indent-size: please update `help=` text to use %(default)s instead of %default -- this will be an error in the future
```