### PR TITLE
Fix type hint for build_ast

### DIFF
--- a/src/flake8/processor.py
+++ b/src/flake8/processor.py
@@ -218,7 +218,7 @@ class FileProcessor:
             (previous_row, previous_column) = end
         return comments, logical, mapping
 
-    def build_ast(self) -> ast.AST:
+    def build_ast(self) -> ast.Module:
         """Build an abstract syntax tree from the list of lines."""
         return ast.parse("".join(self.lines))
 


### PR DESCRIPTION
`ast.parse` returns an `ast.Module` in its default mode, 'exec':

https://github.com/python/typeshed/blob/3ce5502675d3c23394b592f00234fbdfc743a7d5/stdlib/ast.pyi#L159-L167

Therefore this type hint can be more specific.