### PR TITLE
Use new pre-commit config format

### DIFF
--- a/docs/source/user/using-hooks.rst
+++ b/docs/source/user/using-hooks.rst
@@ -10,6 +10,7 @@ started is to add this configuration to your ``.pre-commit-config.yaml``:
 
 .. code-block:: yaml
 
+    repos:
     -   repo: https://github.com/pycqa/flake8
         rev: ''  # pick a git hash / tag to point to
         hooks:


### PR DESCRIPTION
It seems that `pre-commit` now wants a top-level map (rather than a list) for its configuration. Update the example to match the new format.