### PR TITLE
remove indent_size_str

### DIFF
--- a/src/flake8/processor.py
+++ b/src/flake8/processor.py
@@ -92,8 +92,6 @@ class FileProcessor:
         self.indent_level = 0
         #: Number of spaces used for indentation
         self.indent_size = options.indent_size
-        #: String representing the space indentation (DEPRECATED)
-        self.indent_size_str = str(self.indent_size)
         #: Line number in the file
         self.line_number = 0
         #: Current logical line


### PR DESCRIPTION
this was originally added only for pycodestyle which no longer uses it