### PR TITLE
remove 3.5 mention

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -32,7 +32,7 @@ can instead use:
 
     It is **very** important to install |Flake8| on the *correct* version of
     Python for your needs. If you want |Flake8| to properly parse new language
-    features in Python 3.5 (for example), you need it to be installed on 3.5
+    features in Python 3.9 (for example), you need it to be installed on 3.9
     for |Flake8| to understand those features. In many ways, Flake8 is tied to
     the version of Python on which it runs.
 


### PR DESCRIPTION
Python 3.5 is no longer supported, but mentioned in the homepage