### PR TITLE
non-universal bdist

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -95,9 +95,6 @@ flake8.report =
     quiet-filename = flake8.formatting.default:FilenameOnly
     quiet-nothing = flake8.formatting.default:Nothing
 
-[bdist_wheel]
-universal = 1
-
 [mypy]
 check_untyped_defs = true
 disallow_any_generics = true


### PR DESCRIPTION
Flake8 no longer supports Python 2, so there is no need of building universal bdist.