### PR TITLE
Update type hint and expression for _multiprocessing_is_fork()

### DIFF
--- a/src/flake8/checker.py
+++ b/src/flake8/checker.py
@@ -42,7 +42,9 @@ SERIAL_RETRY_ERRNOS = {
 
 def _multiprocessing_is_fork() -> bool:
     """Class state is only preserved when using the `fork` strategy."""
-    return bool(multiprocessing and multiprocessing.get_start_method() == "fork")
+    return bool(
+        multiprocessing and multiprocessing.get_start_method() == "fork"
+    )
 
 
 class Manager:


### PR DESCRIPTION
The type hint should be `-> bool` (the old one was invalid). After fixing that, `mypy` complained that the return value was an `Optional[bool]`, so I updated the internals to wrap the expression is `bool` but happy to change that