### PR TITLE
only write to stdout buffer when buffer object is available

### DIFF
--- a/src/flake8/formatting/base.py
+++ b/src/flake8/formatting/base.py
@@ -184,7 +184,15 @@ class BaseFormatter:
         if self.output_fd is not None:
             self.output_fd.write(output + self.newline)
         if self.output_fd is None or self.options.tee:
-            sys.stdout.buffer.write(output.encode() + self.newline.encode())
+            # sys.stdout might be replaced, and thus could also be
+            # a file like object like io.StringIO, which do not
+            # support the 'buffer' attribute.
+            try:
+                sys.stdout.buffer.write(
+                    output.encode() + self.newline.encode()
+                )
+            except AttributeError:
+                sys.stdout.write(output + self.newline)
 
     def write(self, line: Optional[str], source: Optional[str]) -> None:
         """Write the line either to the output file or stdout.

--- a/tests/unit/test_base_formatter.py
+++ b/tests/unit/test_base_formatter.py
@@ -136,6 +136,33 @@ def test_write_produces_stdout(capsys):
     assert capsys.readouterr().out == f"{line}\n{source}\n"
 
 
+def test_write_without_stdout_buffer():
+    """Verify that stdout writes when it has no buffer."""
+    line = "Something to write"
+    source = "source"
+
+    buffer_side_effect = AttributeError(
+        "'_io.StringIO' object has no \
+        attribute 'buffer'"
+    )
+    buffer_write_mock = mock.Mock(side_effect=buffer_side_effect)
+
+    write_mock = mock.Mock()
+    mock.patch("flake8.formatting.base.sys.stdout.write", write_mock)
+
+    with mock.patch(
+        "flake8.formatting.base.sys.stdout.buffer.write", buffer_write_mock
+    ):
+        formatter = base.BaseFormatter(options())
+        formatter.write(line, source)
+        assert write_mock.called is True
+        assert write_mock.call_count == 2
+        assert write_mock.mock_calls == [
+            mock.call(line + formatter.newline),
+            mock.call(source + formatter.newline),
+        ]
+
+
 class AfterInitFormatter(base.BaseFormatter):
     """Subclass for testing after_init."""
 


### PR DESCRIPTION
I've stumbled too on the issue [mentioned by @Hebarusan](https://github.com/PyCQA/flake8/pull/1382#issuecomment-942587727)  in #1382, that Flake8 raises the error: `AttributeError: '_io.StringIO' object has no attribute 'buffer'` when a Flake8 check fails. 

I took a dive in and found that `sys.stdout` sometimes has the `buffer` attribute, and sometimes it doesn't. 
The [Python documentation about `stdout`](https://docs.python.org/3/library/sys.html#sys.stdout) states: 

> When interactive, the stdout stream is line-buffered. Otherwise, it is block-buffered like regular text files.

And also:

> [...] However, if you are writing a library (and do not control in which context its code will be executed), be aware that the standard streams may be replaced with file-like objects like io.StringIO which do not support the buffer attribute.

And that seems to be the case! 

I've checked this by putting a `breakpoint()` inside the `_write` method (the method from which the `AttributeError` was raised), and printed the result of `type(sys.stdout)`, which was `<class '_io.TextIOWrapper'`. However, without the breakpoint, it printed `<class '_io.StringIO'>`. 

I therefore concluded that both `sys.stdout.buffer.write` and `sys.stdout.write` should work.

