### PR TITLE
Fix ReadTheDocs builds

### DIFF
--- a/docs/source/requirements.txt
+++ b/docs/source/requirements.txt
@@ -2,3 +2,4 @@ sphinx>=1.3.0,!=3.1.0
 sphinx_rtd_theme
 sphinx-prompt
 flake8-polyfill
+docutils!=0.18


### PR DESCRIPTION
docutils 0.18 is busted and needs to be prevented from being installed

Related to https://github.com/sphinx-doc/sphinx/issues/9788

Related to https://github.com/readthedocs/readthedocs.org/issues/8616