### PR TITLE
Don't pin importlib-metadata

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -42,7 +42,7 @@ install_requires =
     mccabe>=0.6.0,<0.7.0
     pycodestyle>=2.8.0,<2.9.0
     pyflakes>=2.4.0,<2.5.0
-    importlib-metadata<4.3;python_version<"3.8"
+    importlib-metadata; python_version<"3.8"
 python_requires = >=3.6
 
 [options.packages.find]


### PR DESCRIPTION
In commit 975a3f45334861ebd8960c00e881443c23654bca, the `importlib-metadata` dependency was pinned to < 4.3. This was apparently to resolve some issues with that package that occured at that time. However, said issues are no longer present and this pinning is preventing packages that have `flake8` as a dependency from using the newer releases of `importlib-metadata` (in my case, this is preventing us from bumping `flake8` used by the OpenStack `hacking` package).

This PR proposes removing the cap as it's no longer necessary and is actively causing issues. I'm hoping that this can be included in a future patch release (i.e. 4.0.2) but if not, I guess a future minor release will have to suffice.