### PR TITLE
Add .nox to default exclude list

### DIFF
--- a/docs/source/manpage.rst
+++ b/docs/source/manpage.rst
@@ -44,7 +44,8 @@ All options available as of Flake8 3.1.0::
                           unified diff provided on standard in by the user.
     --exclude=patterns    Comma-separated list of files or directories to
                           exclude. (Default:
-                          .svn,CVS,.bzr,.hg,.git,__pycache__,.tox,.eggs,*.egg)
+                          .svn,CVS,.bzr,.hg,.git,__pycache__,.tox,.nox,.eggs,
+                          *.egg)
     --filename=patterns   Only check for filenames matching the patterns in this
                           comma-separated list. (Default: *.py)
     --stdin-display-name=STDIN_DISPLAY_NAME

--- a/docs/source/user/invocation.rst
+++ b/docs/source/user/invocation.rst
@@ -98,7 +98,8 @@ And you should see something like:
                             unified diff provided on standard in by the user.
       --exclude=patterns    Comma-separated list of files or directories to
                             exclude.(Default:
-                            .svn,CVS,.bzr,.hg,.git,__pycache__,.tox,.eggs,*.egg)
+                            .svn,CVS,.bzr,.hg,.git,__pycache__,.tox,.nox,.eggs,
+                            *.egg)
       --filename=patterns   Only check for filenames matching the patterns in this
                             comma-separated list. (Default: *.py)
       --format=format       Format errors according to the chosen formatter.

--- a/docs/source/user/options.rst
+++ b/docs/source/user/options.rst
@@ -261,7 +261,7 @@ Options and their Descriptions
 
     Provide a comma-separated list of glob patterns to exclude from checks.
 
-    This defaults to: ``.svn,CVS,.bzr,.hg,.git,__pycache__,.tox,.eggs,*.egg``
+    This defaults to: ``.svn,CVS,.bzr,.hg,.git,__pycache__,.tox,.nox,.eggs,*.egg``
 
     Example patterns:
 

--- a/src/flake8/defaults.py
+++ b/src/flake8/defaults.py
@@ -9,6 +9,7 @@ EXCLUDE = (
     ".git",
     "__pycache__",
     ".tox",
+    ".nox",
     ".eggs",
     "*.egg",
 )


### PR DESCRIPTION
I think this is everywhere that it should be added to, docs and `defaults.py`.

Closes #1442