### PR TITLE
allow importlib-metadata to be updated

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -42,7 +42,7 @@ install_requires =
     mccabe>=0.6.0,<0.7.0
     pycodestyle>=2.8.0,<2.9.0
     pyflakes>=2.4.0,<2.5.0
-    importlib-metadata<4.3;python_version<"3.8"
+    importlib-metadata!=4.3;python_version<"3.8"
 python_requires = >=3.6
 
 [options.packages.find]


### PR DESCRIPTION
# Problem

I would like to be able to update `importlib-metadata` in project using `flake8`  (specifically: https://github.com/inmanta/inmanta-core/pull/3393).

Currently this fails:

```
The conflict is caused by:
    The user requested importlib_metadata==4.8.1
    click 8.0.3 depends on importlib-metadata; python_version < "3.8"
    build 0.7.0 depends on importlib-metadata>=0.22; python_version < "3.8"
    flake8 4.0.1 depends on importlib-metadata<4.3; python_version < "3.8"
```


# Solution

1. I have been able to trace this constraint back to here: https://github.com/PyCQA/flake8/commit/975a3f45334861ebd8960c00e881443c23654bca
2. it indicates that 4.3 is broken in some way (I don't know how)
3. comments indicate this approach is not good
4. I propose to make the constraint more specific, to just exclude the broken version 