### PR TITLE
require coverage 6.x and simplify config

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,5 +1,4 @@
 [run]
-parallel = True
 branch = True
 source =
     flake8
@@ -7,12 +6,6 @@ source =
 omit =
     # Don't complain if non-runnable code isn't run
     */__main__.py
-
-[paths]
-source =
-    src/flake8
-    .tox/*/lib/python*/site-packages/flake8
-    .tox/pypy/site-packages/flake8
 
 [report]
 show_missing = True

--- a/tox.ini
+++ b/tox.ini
@@ -5,10 +5,9 @@ envlist = py36,py37,py38,flake8,linters,docs
 [testenv]
 deps =
     pytest!=3.0.5,!=5.2.3
-    coverage
+    coverage>=6
 commands =
     coverage run -m pytest {posargs}
-    coverage combine
     coverage report
     # ensure 100% coverage of tests
     coverage report --fail-under 100 --include tests/*


### PR DESCRIPTION
coverage 6.x has smarter `paths` discovery so we no longer need our custom config