### PR TITLE
allow additional default configuration locations

### DIFF
--- a/src/flake8/options/config.py
+++ b/src/flake8/options/config.py
@@ -11,12 +11,12 @@ from typing import Tuple
 from flake8.options.manager import OptionManager
 
 LOG = logging.getLogger(__name__)
-DEFAULT_CANDIDATES = ("setup.cfg", "tox.ini", ".flake8")
-ADDITIONAL_CANDIDATES = ("flake8",)
-ADDITIONAL_LOCATIONS = (
+DEFAULT_CANDIDATES = ["setup.cfg", "tox.ini", ".flake8"]
+ADDITIONAL_CANDIDATES = ["flake8"]
+ADDITIONAL_LOCATIONS = [
     os.path.expanduser(r"~"),
     os.path.expanduser(r"~/.config"),
-)
+]
 
 
 def _is_config(path: str) -> bool:

--- a/src/flake8/options/config.py
+++ b/src/flake8/options/config.py
@@ -13,8 +13,10 @@ from flake8.options.manager import OptionManager
 LOG = logging.getLogger(__name__)
 DEFAULT_CANDIDATES = ("setup.cfg", "tox.ini", ".flake8")
 ADDITIONAL_CANDIDATES = ("flake8",)
-ADDITIONAL_LOCATIONS = (os.path.expanduser(r'~'),
-                        os.path.expanduser(r'~/.config'))
+ADDITIONAL_LOCATIONS = (
+    os.path.expanduser(r"~"),
+    os.path.expanduser(r"~/.config"),
+)
 
 
 def _is_config(path: str) -> bool:

--- a/tests/integration/test_main.py
+++ b/tests/integration/test_main.py
@@ -9,6 +9,10 @@ import pytest
 from flake8 import utils
 from flake8.main import cli
 
+from flake8.options import config
+config.ADDITIONAL_LOCATIONS = ()
+config.ADDITIONAL_CANDIDATES = ()
+
 
 def test_diff_option(tmpdir, capsys):
     """Ensure that `flake8 --diff` works."""

--- a/tests/integration/test_main.py
+++ b/tests/integration/test_main.py
@@ -8,8 +8,8 @@ import pytest
 
 from flake8 import utils
 from flake8.main import cli
-
 from flake8.options import config
+
 config.ADDITIONAL_LOCATIONS = ()
 config.ADDITIONAL_CANDIDATES = ()
 

--- a/tests/integration/test_main.py
+++ b/tests/integration/test_main.py
@@ -10,8 +10,8 @@ from flake8 import utils
 from flake8.main import cli
 from flake8.options import config
 
-config.ADDITIONAL_LOCATIONS = ()
-config.ADDITIONAL_CANDIDATES = ()
+config.ADDITIONAL_LOCATIONS = []
+config.ADDITIONAL_CANDIDATES = []
 
 
 def test_diff_option(tmpdir, capsys):

--- a/tests/unit/test_file_checker.py
+++ b/tests/unit/test_file_checker.py
@@ -39,7 +39,6 @@ def test_raises_exception_on_failed_plugin(tmp_path, default_options):
         "parameters": dict(),
         "plugin": mock.MagicMock(side_effect=ValueError),
     }
-    """Verify a failing plugin results in an plugin error"""
     fchecker = checker.FileChecker(
         str(foobar), checks=[], options=default_options
     )

--- a/tests/unit/test_options_config.py
+++ b/tests/unit/test_options_config.py
@@ -8,8 +8,8 @@ from flake8.options.manager import OptionManager
 
 
 def test_config_not_found_returns_none(tmp_path):
-    config.ADDITIONAL_LOCATIONS = ()
-    config.ADDITIONAL_CANDIDATES = ()
+    config.ADDITIONAL_LOCATIONS = []
+    config.ADDITIONAL_CANDIDATES = []
     assert config._find_config_file(str(tmp_path)) is None
 
 

--- a/tests/unit/test_options_config.py
+++ b/tests/unit/test_options_config.py
@@ -8,6 +8,8 @@ from flake8.options.manager import OptionManager
 
 
 def test_config_not_found_returns_none(tmp_path):
+    config.ADDITIONAL_LOCATIONS = ()
+    config.ADDITIONAL_CANDIDATES = ()
     assert config._find_config_file(str(tmp_path)) is None
 
 


### PR DESCRIPTION
Hi,
The current configuration finder only looks in the current directory and its parents. This makes it impossible to have a configuration in other default locations such as the userhome (e.g. ~/.flake8 or ~/.config/flake8)). The only way to address such configuration is to always use `--append-config` or `--config` options.
As it is quite common (I think) to use the same configuration for each project it would be nice if there are some default locations outside the current or project working directory, so flake8 can use these outside locations as fallback before using the internal defaults.
With this pull request I try to not change the original behaviour at all - only when flake8 does not find a suitable configuration my proposal is to scan some more locations before using the internal defaults (right now: ~/.config and ~).
Best regards, 
Christian
