### PR TITLE
fix docs build

### DIFF
--- a/src/flake8/checker.py
+++ b/src/flake8/checker.py
@@ -243,8 +243,7 @@ class Manager:
         or whether to run them in serial.
 
         If running the checks in parallel causes a problem (e.g.,
-        https://github.com/pycqa/flake8/issues/117) this also implements
-        fallback to serial processing.
+        :issue:`117`) this also implements fallback to serial processing.
         """
         try:
             if self.jobs > 1 and len(self.checkers) > 1:


### PR DESCRIPTION
originally failing with:

```
Warning, treated as error:
/tmp/flake8/.tox/docs/lib/python3.8/site-packages/flake8/checker.py:docstring of flake8.checker.Manager.run:6:hardcoded link 'https://github.com/pycqa/flake8/issues/117' could be replaced by an extlink (try using ':issue:`117`' instead)
```