### PR TITLE
remove triple logged stacktrace on unknown plugin args

### DIFF
--- a/src/flake8/checker.py
+++ b/src/flake8/checker.py
@@ -342,7 +342,6 @@ class FileChecker:
         try:
             self.processor.keyword_arguments_for(plugin.parameters, arguments)
         except AttributeError as ae:
-            LOG.error("Plugin requested unknown parameters.")
             raise exceptions.PluginRequestedUnknownParameters(
                 plugin_name=plugin.display_name, exception=ae
             )

--- a/src/flake8/processor.py
+++ b/src/flake8/processor.py
@@ -251,9 +251,8 @@ class FileProcessor:
                 continue
             try:
                 arguments[param] = getattr(self, param)
-            except AttributeError as exc:
+            except AttributeError:
                 if required:
-                    LOG.exception(exc)
                     raise
                 else:
                     LOG.warning(


### PR DESCRIPTION
when run with `flake8 -v` the stacktrace for this error was getting logged thrice