### PR TITLE
remove slow debug() log

### DIFF
--- a/src/flake8/checker.py
+++ b/src/flake8/checker.py
@@ -337,7 +337,6 @@ class FileChecker:
 
     def run_check(self, plugin: LoadedPlugin, **arguments: Any) -> Any:
         """Run the check in a single plugin."""
-        LOG.debug("Running %r with %r", plugin, arguments)
         assert self.processor is not None
         try:
             params = self.processor.keyword_arguments_for(


### PR DESCRIPTION
flake8 spends ~5-6% of `flake8 -j1 src` on this line

___

personally I don't use any of the `debug(...)` logging information and prefer to use `pdb` myself.  I wouldn't be opposed to removing the rest of the debug lines as well -- though this one appears to be the most performance impacting one (even at the default log level)