### PR TITLE
Remove duplicated example from `options.rst`

### DIFF
--- a/docs/source/user/options.rst
+++ b/docs/source/user/options.rst
@@ -825,9 +825,6 @@ Options and their Descriptions
         enable-extensions =
             H111,
             G123
-        enable_extensions =
-            H111,
-            G123
 
 
 .. option:: --exit-zero


### PR DESCRIPTION
Here's how it looks right now: https://flake8.pycqa.org/en/latest/user/options.html#cmdoption-flake8-enable-extensions

<img width="694" alt="Снимок экрана 2022-01-28 в 11 40 42" src="https://user-images.githubusercontent.com/4660275/151514758-d4ef0077-d069-47ad-8c7e-0bd7a9ddb114.png">

Probably, this is not intended.