### PR TITLE
make --ignore order consistent

### DIFF
--- a/src/flake8/options/aggregator.py
+++ b/src/flake8/options/aggregator.py
@@ -35,11 +35,9 @@ def aggregate_options(
     default_values.extended_default_ignore = (
         manager.extended_default_ignore.copy()
     )
-    LOG.debug(
-        "Extended default ignore list: %s", list(extended_default_ignore)
-    )
-    extended_default_ignore.update(default_values.ignore)
-    default_values.ignore = list(extended_default_ignore)
+    LOG.debug("Extended default ignore list: %s", extended_default_ignore)
+    extended_default_ignore.extend(default_values.ignore)
+    default_values.ignore = extended_default_ignore
     LOG.debug("Merged default ignore list: %s", default_values.ignore)
 
     extended_default_select = manager.extended_default_select.copy()

--- a/src/flake8/options/manager.py
+++ b/src/flake8/options/manager.py
@@ -10,7 +10,6 @@ from typing import List
 from typing import Mapping
 from typing import Optional
 from typing import Sequence
-from typing import Set
 from typing import Tuple
 from typing import Type
 from typing import Union
@@ -353,8 +352,8 @@ class OptionManager:
 
         self.config_options_dict: Dict[str, Option] = {}
         self.options: List[Option] = []
-        self.extended_default_ignore: Set[str] = set()
-        self.extended_default_select: Set[str] = set()
+        self.extended_default_ignore: List[str] = []
+        self.extended_default_select: List[str] = []
 
         self._current_group: Optional[argparse._ArgumentGroup] = None
 
@@ -415,7 +414,7 @@ class OptionManager:
             extend the default ignore list.
         """
         LOG.debug("Extending default ignore list with %r", error_codes)
-        self.extended_default_ignore.update(error_codes)
+        self.extended_default_ignore.extend(error_codes)
 
     def extend_default_select(self, error_codes: Sequence[str]) -> None:
         """Extend the default select list with the error codes provided.
@@ -425,7 +424,7 @@ class OptionManager:
             to extend the default select list.
         """
         LOG.debug("Extending default select list with %r", error_codes)
-        self.extended_default_select.update(error_codes)
+        self.extended_default_select.extend(error_codes)
 
     def parse_args(
         self,

--- a/tests/integration/test_plugins.py
+++ b/tests/integration/test_plugins.py
@@ -104,7 +104,7 @@ def test_local_plugin_can_add_option(local_config):
 
     args = aggregator.aggregate_options(option_manager, cfg, cfg_dir, argv)
 
-    assert args.extended_default_select == {"XE", "F", "E", "W", "C90"}
+    assert args.extended_default_select == ["XE", "C90", "F", "E", "W"]
     assert args.anopt == "foo"
 
 

--- a/tests/unit/test_option_manager.py
+++ b/tests/unit/test_option_manager.py
@@ -156,10 +156,10 @@ def test_parse_args_normalize_paths(optmanager):
 
 def test_extend_default_ignore(optmanager):
     """Verify that we update the extended default ignore list."""
-    assert optmanager.extended_default_ignore == set()
+    assert optmanager.extended_default_ignore == []
 
     optmanager.extend_default_ignore(["T100", "T101", "T102"])
-    assert optmanager.extended_default_ignore == {"T100", "T101", "T102"}
+    assert optmanager.extended_default_ignore == ["T100", "T101", "T102"]
 
 
 def test_optparse_normalize_callback_option_legacy(optmanager):


### PR DESCRIPTION
for #1550 

I think this is worth doing anyway -- though we should reconsider whether showing the configured values as "default" in `--help` is desirable or not