### PR TITLE
Add debug printout when reading config file

### DIFF
--- a/src/flake8/options/config.py
+++ b/src/flake8/options/config.py
@@ -61,6 +61,7 @@ def load_config(
 
     cfg = configparser.RawConfigParser()
     if config is not None:
+        LOG.debug("Reading config file %s", config)
         if not cfg.read(config, encoding="UTF-8"):
             raise exceptions.ExecutionError(
                 f"The specified config file does not exist: {config}"
@@ -72,6 +73,7 @@ def load_config(
     # TODO: remove this and replace it with configuration modifying plugins
     # read the additional configs afterwards
     for filename in extra:
+        LOG.debug("Reading extra config file %s", config)
         cfg.read(filename, encoding="UTF-8")
 
     return cfg, cfg_dir


### PR DESCRIPTION
Add a debug printout when reading the (extra) config files(s). A similar line was available in version 3.x before the removal of the user-specific config file parsing.