### PR TITLE
Support hyphens within a flake8 custom plugin code #1568

### DIFF
--- a/src/flake8/utils.py
+++ b/src/flake8/utils.py
@@ -56,7 +56,7 @@ class _Token(NamedTuple):
 _CODE, _FILE, _COLON, _COMMA, _WS = "code", "file", "colon", "comma", "ws"
 _EOF = "eof"
 _FILE_LIST_TOKEN_TYPES = [
-    (re.compile(r"[A-Z]+[0-9]*(?=$|\s|,)"), _CODE),
+    (re.compile(r"[A-Z]+[A-Z0-9-]*(?=$|\s|,)"), _CODE),
     (re.compile(r"[^\s:,]+"), _FILE),
     (re.compile(r"\s*:\s*"), _COLON),
     (re.compile(r"\s*,\s*"), _COMMA),

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -99,6 +99,11 @@ def test_parse_comma_separated_list(value, expected):
             "f.py: ABC123",
             [("f.py", ["ABC123"])],
         ),
+        # hyphens are allowed
+        (
+            "f.py: COMPANY-NAME-SPACE-123,COMPANY-NAME-SPACE-321",
+            [("f.py", ["COMPANY-NAME-SPACE-123", "COMPANY-NAME-SPACE-321"])],
+        ),
     ),
 )
 def test_parse_files_to_codes_mapping(value, expected):
@@ -118,8 +123,6 @@ def test_parse_files_to_codes_mapping(value, expected):
         "f.py:E,g.py"
         # colon while looking for codes
         "f.py::",
-        # no separator between
-        "f.py:E1F1",
     ),
 )
 def test_invalid_file_list(value):


### PR DESCRIPTION
Prior to this change, a code had to be formatted as a series of characters
followed by a series of numbers.

This change updates the format to require the first character to be a
letter, followed by any number of letters, numbers, or hyphens.

Implements the feature request from https://github.com/PyCQA/flake8/issues/1568

There are no docs updates yet but I'm happy to update them if the feature request is approved.