### PR TITLE
Bump importlib-metadata version to <=4.3

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -42,7 +42,7 @@ install_requires =
     mccabe>=0.7.0,<0.8.0
     pycodestyle>=2.8.0,<2.9.0
     pyflakes>=2.4.0,<2.5.0
-    importlib-metadata<4.3;python_version<"3.8"
+    importlib-metadata<=4.3;python_version<"3.8"
 python_requires = >=3.6.1
 
 [options.packages.find]


### PR DESCRIPTION
Recently I found it necessary to use Flake8 alongside MKDocs in version 1.3. Unfortunately, MKDocs requires importlib-metadata>=4.3 when Flake8 requires importlib-metadata<4.3. That's a really unfortunate coincidence, therefore I decided to pay a visit to Flake8 repository and propose a slight dependency version bump. AFAIK there are no game-breaking API changes in importlib-metadata 4.3.