### PR TITLE
Enforce usage of fork method on macOS

### DIFF
--- a/tests/integration/test_checker.py
+++ b/tests/integration/test_checker.py
@@ -292,11 +292,11 @@ def test_acquire_when_multiprocessing_pool_can_initialize():
 
     This simulates the behaviour on most common platforms.
     """
-    with mock.patch("multiprocessing.Pool") as pool:
+    with mock.patch("multiprocessing.get_context") as context:
         result = checker._try_initialize_processpool(2)
 
-    pool.assert_called_once_with(2, checker._pool_init)
-    assert result is pool.return_value
+    context.return_value.Pool.assert_called_once_with(2, checker._pool_init)
+    assert result is context.return_value.Pool.return_value
 
 
 def test_acquire_when_multiprocessing_pool_can_not_initialize():
@@ -311,10 +311,11 @@ def test_acquire_when_multiprocessing_pool_can_not_initialize():
 
     https://github.com/python/cpython/blob/4e02981de0952f54bf87967f8e10d169d6946b40/Lib/multiprocessing/synchronize.py#L30-L33
     """
-    with mock.patch("multiprocessing.Pool", side_effect=ImportError) as pool:
+    with mock.patch("multiprocessing.get_context") as context:
+        context.return_value.Pool.side_effect = ImportError
         result = checker._try_initialize_processpool(2)
 
-    pool.assert_called_once_with(2, checker._pool_init)
+    context.return_value.Pool.assert_called_once_with(2, checker._pool_init)
     assert result is None
 
 


### PR DESCRIPTION
Hello there! 👋 

I saw this issue https://github.com/PyCQA/flake8/issues/1337 and I would like to suggest this quick fix to restore the multiprocessing module for macOS while we wait for this https://github.com/PyCQA/flake8/issues/1337#issuecomment-1040277568.

I am aware that an issue with macOS and fork has been found by the Python core developers, but I do not recall having any issues using flake8 on my MacBook with Python 3.7.

I am using Python 3.9 on a big project and running flake8 takes about 1m 20s without the multiprocessing module. With this fix, it now takes about 24s.

@asottile Do you think it would be reasonable to allow macOS users to run flake8 with the fork method while we wait for the new implementation? If we shouldn't restore it by default for all users, could we add a temporary option to the command line (something like `--macos-enable-jobs`)?

Thanks!