### PR TITLE
ignore config files that partially parse as flake8 configs

### DIFF
--- a/src/flake8/options/config.py
+++ b/src/flake8/options/config.py
@@ -29,9 +29,9 @@ def _find_config_file(path: str) -> Optional[str]:
         home_stat = None
 
     dir_stat = _stat_key(path)
-    cfg = configparser.RawConfigParser()
     while True:
         for candidate in ("setup.cfg", "tox.ini", ".flake8"):
+            cfg = configparser.RawConfigParser()
             cfg_path = os.path.join(path, candidate)
             try:
                 cfg.read(cfg_path, encoding="UTF-8")

--- a/tests/unit/test_options_config.py
+++ b/tests/unit/test_options_config.py
@@ -21,7 +21,9 @@ def test_config_file_without_section_is_not_considered(tmp_path):
 
 
 def test_config_file_with_parse_error_is_not_considered(tmp_path, caplog):
-    tmp_path.joinpath("setup.cfg").write_text("[error")
+    # the syntax error here is deliberately to trigger a partial parse
+    # https://github.com/python/cpython/issues/95546
+    tmp_path.joinpath("setup.cfg").write_text("[flake8]\nx = 1\n...")
 
     assert config._find_config_file(str(tmp_path)) is None
 


### PR DESCRIPTION
resolves #1647