### PR TITLE
fix documentation of color configuruation

### DIFF
--- a/docs/source/user/options.rst
+++ b/docs/source/user/options.rst
@@ -193,7 +193,7 @@ Options and their Descriptions
 
     Possible options are ``auto``, ``always``, and ``never``.
 
-    This **can** be specified in config files.
+    This **can not** be specified in config files.
 
     When color is enabled, the following substitutions are enabled:
 
@@ -207,12 +207,6 @@ Options and their Descriptions
     - ``%(cyan)s``
     - ``%(white)s``
     - ``%(reset)s``
-
-    Example config file usage:
-
-    .. code-block:: ini
-
-        color = never
 
 
 .. option:: --count


### PR DESCRIPTION
This PR fixes https://github.com/PyCQA/flake8/issues/1661 , where the `color` option was not being picked up from the config file, which I assumed was a bug since the documentation suggests it should be configurable from there: https://flake8.pycqa.org/en/latest/user/options.html#cmdoption-flake8-color