### PR TITLE
include bin/ subdirectory in sdist tarballs

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,6 +2,7 @@ include *.rst
 include CONTRIBUTORS.txt
 include LICENSE
 include *.ini
+graft bin
 global-exclude *.pyc
 recursive-include docs *.rst *.py
 recursive-include tests *.py *.ini *.rst *_diff


### PR DESCRIPTION
without that the testsuite is failing on the missing files