### PR TITLE
Prefer extend-ignore over ignore in general examples

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -60,11 +60,11 @@ If you only want to see the instances of a specific warning or error, you can
 
     flake8 --select E123,W503 path/to/code/
 
-Alternatively, if you want to *ignore* only one specific warning or error:
+Alternatively, if you want to add a specific warning or error to *ignore*:
 
 .. code::
 
-    flake8 --ignore E24,W504 path/to/code/
+    flake8 --extend-ignore E203,W234 path/to/code/
 
 Please read our user guide for more information about how to use and configure
 |Flake8|.

--- a/docs/source/user/configuration.rst
+++ b/docs/source/user/configuration.rst
@@ -90,7 +90,7 @@ Let's actually look at |Flake8|'s own configuration section:
 .. code-block:: ini
 
     [flake8]
-    ignore = D203
+    extend-ignore = E203
     exclude = .git,__pycache__,docs/source/conf.py,old,build,dist
     max-complexity = 10
 
@@ -98,7 +98,7 @@ This is equivalent to:
 
 .. prompt:: bash
 
-    flake8 --ignore D203 \
+    flake8 --extend-ignore E203 \
              --exclude .git,__pycache__,docs/source/conf.py,old,build,dist \
              --max-complexity 10
 
@@ -107,7 +107,7 @@ In our case, if we wanted to, we could also do
 .. code-block:: ini
 
     [flake8]
-    ignore = D203
+    extend-ignore = E203
     exclude =
         .git,
         __pycache__,
@@ -122,7 +122,7 @@ This allows us to add comments for why we're excluding items, e.g.
 .. code-block:: ini
 
     [flake8]
-    ignore = D203
+    extend-ignore = E203
     exclude =
         # No need to traverse our git directory
         .git,
@@ -190,7 +190,7 @@ look at a portion of a project's Flake8 configuration in their ``tox.ini``:
     # H404: multi line docstring should start without a leading new line
     # H405: multi line docstring summary not separated with an empty line
     # H501: Do not use self.__dict__ for string formatting
-    ignore = H101,H202,H233,H301,H306,H401,H403,H404,H405,H501
+    extend-ignore = H101,H202,H233,H301,H306,H401,H403,H404,H405,H501
 
 They use the comments to describe the check but they could also write this as:
 
@@ -198,7 +198,7 @@ They use the comments to describe the check but they could also write this as:
 
     [flake8]
     # it's not a bug that we aren't using all of hacking
-    ignore =
+    extend-ignore =
         # H101: Use TODO(NAME)
         H101,
         # H202: assertRaises Exception too broad


### PR DESCRIPTION
See #1679

I changed the error codes in `index.rst` so they weren't ones that are disabled by default.

I changed the error code in `configuration.rst` as `E203` is what is actually ignored by flake8 now: https://github.com/PyCQA/flake8/blob/4d1a72afc2825480b0d562a2c13c3a94c923a174/tox.ini#L121