### PR TITLE
Make it easy for third party patch to support pyproject.toml

### DIFF
--- a/src/flake8/options/config.py
+++ b/src/flake8/options/config.py
@@ -11,6 +11,8 @@ from flake8.options.manager import OptionManager
 
 LOG = logging.getLogger(__name__)
 
+CONFIG_FILES = ("setup.cfg", "tox.ini", ".flake8")
+
 
 def _stat_key(s: str) -> tuple[int, int]:
     # same as what's used by samefile / samestat
@@ -28,7 +30,7 @@ def _find_config_file(path: str) -> str | None:
 
     dir_stat = _stat_key(path)
     while True:
-        for candidate in ("setup.cfg", "tox.ini", ".flake8"):
+        for candidate in CONFIG_FILES:
             cfg = configparser.RawConfigParser()
             cfg_path = os.path.join(path, candidate)
             try:


### PR DESCRIPTION
I use [pyproject-flake8](https://github.com/csachs/pyproject-flake8) to make flake8 support pyproject.toml

For flake8>=5.0, code have to be:
```py
class FixFilenames(ast.NodeTransformer):
    tuple_of_interest = ("setup.cfg", "tox.ini", ".flake8")

    modern = sys.version_info[0] >= 3 and sys.version_info[1] > 7

    inner_type = ast.Constant if modern else ast.Str
    inner_type_field = "value" if modern else "s"

    fix_applied = False

    def visit_Tuple(self, node: ast.Tuple) -> ast.Tuple:
        if all(isinstance(el, self.inner_type) for el in node.elts) and set(
            self.tuple_of_interest
        ) == {getattr(el, self.inner_type_field) for el in node.elts}:
            node.elts.append(
                self.inner_type(**{self.inner_type_field: "pyproject.toml"})
            )
            ast.fix_missing_locations(node)
            self.fix_applied = True
        return node
    ...
```

But if there is a var as: `CONFIG_FILES = ("setup.cfg", "tox.ini", ".flake8")`
Code of the pyproject-flake8 patch to extend config files can be as simple as:
```py
flake8.options.config.CONFIG_FILES += ('pyproject.toml',)
```