### PR TITLE
fix documentation for the --count option

### DIFF
--- a/src/flake8/main/options.py
+++ b/src/flake8/main/options.py
@@ -159,8 +159,8 @@ def register_default_options(option_manager: OptionManager) -> None:
         "--count",
         action="store_true",
         parse_from_config=True,
-        help="Print total number of errors to standard output and "
-        "set the exit code to 1 if total is not empty.",
+        help="Print total number of errors to standard output after "
+        "all other output.",
     )
 
     add_option(


### PR DESCRIPTION
It erroneously claimed that it set the application exit code to 1 if the count was greater than 1. However, this is false, because the --count option doesn't modify the error code at any time.

If the count was greater than 1, then the exit code was already 1, even in the absence of --count, unless --exit-zero was used.

This documentation bug resulted in people reading the `flake8 --help` output and believing that --count is mandatory in order to ensure that flake8 produces errors in automated processes (such as CI scripts) when flake8 violations are detected.