### PR TITLE
Emit error on invalid config

### DIFF
--- a/src/flake8/options/config.py
+++ b/src/flake8/options/config.py
@@ -20,7 +20,7 @@ def _stat_key(s: str) -> tuple[int, int]:
 
 
 def _walk_up_directories_to_root_or_home(
-    path: str
+    path: str,
 ) -> Generator[str, None, None]:
     """Walk upwards from the given directory.
 


### PR DESCRIPTION
Emit an error message if the configuration is invalid due to multiple
configuration files.

This shows how we can easily emit an error in the simplest case,
though we can also use _walk_up_directories_to_root_or_home to make this more
robust.

Resolves https://github.com/PyCQA/flake8/issues/1704.