### PR TITLE
Add link to GitHub Sponsors for primary maintainer

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: asottile


### PR DESCRIPTION
resolves #1700 

`@sigmavirus24` is unable to be sponsored due to work, but I'll throw mine in there

if we decide on adding tidelift -- there's also a field for tidelift here as well [for example](https://github.com/pytest-dev/pytest/blob/2be1b8f3559570c456f4bf64fea8067e368dcdfd/.github/FUNDING.yml#L4)