### PR TITLE
Raise a exception if append-config files does not exist

### DIFF
--- a/src/flake8/options/config.py
+++ b/src/flake8/options/config.py
@@ -87,7 +87,10 @@ def load_config(
     # TODO: remove this and replace it with configuration modifying plugins
     # read the additional configs afterwards
     for filename in extra:
-        cfg.read(filename, encoding="UTF-8")
+        if not cfg.read(filename, encoding="UTF-8"):
+            raise exceptions.ExecutionError(
+                f"The specified config file does not exist: {filename}"
+            )
 
     return cfg, cfg_dir
 

--- a/tests/unit/test_options_config.py
+++ b/tests/unit/test_options_config.py
@@ -222,6 +222,11 @@ def test_load_config_missing_file_raises_exception(capsys):
         config.load_config("foo.cfg", [])
 
 
+def test_load_config_missing_append_config_raise_exception():
+    with pytest.raises(exceptions.ExecutionError):
+        config.load_config(None, ["dont_exist_config.cfg"], isolated=False)
+
+
 def test_invalid_ignore_codes_raise_error(tmpdir, opt_manager):
     tmpdir.join("setup.cfg").write("[flake8]\nignore = E203, //comment")
     with tmpdir.as_cwd():


### PR DESCRIPTION
This PR resolves https://github.com/PyCQA/flake8/issues/1729 by raising  a exception if append-config files does not exist