### PR TITLE
remove optparse support

### DIFF
--- a/tests/unit/test_option_manager.py
+++ b/tests/unit/test_option_manager.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 import argparse
 import os
-from unittest import mock
 
 import pytest
 
@@ -168,96 +167,6 @@ def test_extend_default_ignore(optmanager):
 
     optmanager.extend_default_ignore(["T100", "T101", "T102"])
     assert optmanager.extended_default_ignore == ["T100", "T101", "T102"]
-
-
-def test_optparse_normalize_callback_option_legacy(optmanager):
-    """Test the optparse shim for `callback=`."""
-    callback_foo = mock.Mock()
-    optmanager.add_option(
-        "--foo",
-        action="callback",
-        callback=callback_foo,
-        callback_args=(1, 2),
-        callback_kwargs={"a": "b"},
-    )
-    callback_bar = mock.Mock()
-    optmanager.add_option(
-        "--bar",
-        action="callback",
-        type="string",
-        callback=callback_bar,
-    )
-    callback_baz = mock.Mock()
-    optmanager.add_option(
-        "--baz",
-        action="callback",
-        type="string",
-        nargs=2,
-        callback=callback_baz,
-    )
-
-    optmanager.parse_args(["--foo", "--bar", "bararg", "--baz", "1", "2"])
-
-    callback_foo.assert_called_once_with(
-        mock.ANY,  # the option / action instance
-        "--foo",
-        None,
-        mock.ANY,  # the OptionParser / ArgumentParser
-        1,
-        2,
-        a="b",
-    )
-    callback_bar.assert_called_once_with(
-        mock.ANY,  # the option / action instance
-        "--bar",
-        "bararg",
-        mock.ANY,  # the OptionParser / ArgumentParser
-    )
-    callback_baz.assert_called_once_with(
-        mock.ANY,  # the option / action instance
-        "--baz",
-        ("1", "2"),
-        mock.ANY,  # the OptionParser / ArgumentParser
-    )
-
-
-@pytest.mark.parametrize(
-    ("type_s", "input_val", "expected"),
-    (
-        ("int", "5", 5),
-        ("long", "6", 6),
-        ("string", "foo", "foo"),
-        ("float", "1.5", 1.5),
-        ("complex", "1+5j", 1 + 5j),
-        # optparse allows this but does not document it
-        ("str", "foo", "foo"),
-    ),
-)
-def test_optparse_normalize_types(optmanager, type_s, input_val, expected):
-    """Test the optparse shim for type="typename"."""
-    optmanager.add_option("--foo", type=type_s)
-    opts = optmanager.parse_args(["--foo", input_val])
-    assert opts.foo == expected
-
-
-def test_optparse_normalize_choice_type(optmanager):
-    """Test the optparse shim for type="choice"."""
-    optmanager.add_option("--foo", type="choice", choices=("1", "2", "3"))
-    opts = optmanager.parse_args(["--foo", "1"])
-    assert opts.foo == "1"
-    # fails to parse
-    with pytest.raises(SystemExit):
-        optmanager.parse_args(["--foo", "4"])
-
-
-def test_optparse_normalize_help(optmanager, capsys):
-    """Test the optparse shim for %default in help text."""
-    optmanager.add_option("--foo", default="bar", help="default: %default")
-    with pytest.raises(SystemExit):
-        optmanager.parse_args(["--help"])
-    out, err = capsys.readouterr()
-    output = out + err
-    assert "default: bar" in output
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
been deprecated for 2+ years, time to remove it -- should make reworking this easier

___

here's the error messages that you'll see as well as how to fix things:


## you have `%default` (optparse type) => `%(default)s`

error:

```console
$ flake8 --help
...
  File "/usr/lib/python3.10/argparse.py", line 642, in _expand_help
    return self._get_help_string(action) % params
TypeError: %d format: a real number is required, not dict
```

## you have `type='callback'`, not really any full replacement

error:

```console
$ flake8 t.py
...
  File "/home/asottile/workspace/flake8/a.py", line 7, in add_options
    parser.add_option(
  File "/home/asottile/workspace/flake8/src/flake8/options/manager.py", line 278, in add_option
    option = Option(*args, **kwargs)
TypeError: Option.__init__() got an unexpected keyword argument 'callback'
```

## you have `type='int'` => `type=int` (or other types)

```console
$ flake8 t.py
...
  File "/home/asottile/workspace/flake8/a.py", line 7, in add_options
    parser.add_option("--foo", type="int")
  File "/home/asottile/workspace/flake8/src/flake8/options/manager.py", line 281, in add_option
    self._current_group.add_argument(*option_args, **option_kwargs)
  File "/usr/lib/python3.10/argparse.py", line 1440, in add_argument
    raise ValueError('%r is not callable' % (type_func,))
ValueError: 'int' is not callable
```
