### PR TITLE
Enable linting of stub files (`.pyi`) in pre-commit hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -3,5 +3,6 @@
     description: '`flake8` is a command-line utility for enforcing style consistency across Python projects.'
     entry: flake8
     language: python
-    types: [python]
+    types_or: [python, pyi]
     require_serial: true
+    minimum_pre_commit_version: 2.9.2


### PR DESCRIPTION
Enable support for `pyi` files when using `flake8` through `pre-commit`. This will run flake8 on stub files in addition to source files. 

Note that by default flake8 doesn't run checks on `pyi` files, and most commonly the [flake8-pyi plugin](https://pypi.org/project/flake8-pyi/) is used to enable those files types and check them. However, without the change in the pre-commit config file, the stub files are still ignored.

References:
1. [The same file on black](https://github.com/psf/black/blob/main/.pre-commit-hooks.yaml)
2. [pre-commit docs](https://github.com/psf/black/blob/main/.pre-commit-hooks.yaml)
3. [Same PR on pyupgrade](https://github.com/asottile/pyupgrade/pull/771)
4. [Same PR on absolufy-imports](https://github.com/MarcoGorelli/absolufy-imports/pull/77)