### PR TITLE
Update VALID_CODE_PREFIX

### DIFF
--- a/src/flake8/defaults.py
+++ b/src/flake8/defaults.py
@@ -43,4 +43,4 @@ NOQA_INLINE_REGEXP = re.compile(
 
 NOQA_FILE = re.compile(r"\s*# flake8[:=]\s*noqa", re.I)
 
-VALID_CODE_PREFIX = re.compile("^[A-Z]{1,3}[0-9]{0,3}$", re.ASCII)
+VALID_CODE_PREFIX = re.compile("^[A-Z]{1,3}[0-9]{0,4}$", re.ASCII)


### PR DESCRIPTION
Change VALID_CODE_PREFIX variable to allow codes with 4 digits.

With this change we can use plugins (such as [this](https://github.com/orsinium-labs/flake8-pylint) one) to connect Flake8 and PyLint, which uses message codes described above (examples here https://pylint.pycqa.org/en/latest/user_guide/messages/messages_overview.html)

Refers to (and fixes) #1777 