### PR TITLE
Update configuration.rst

### DIFF
--- a/docs/source/user/configuration.rst
+++ b/docs/source/user/configuration.rst
@@ -31,6 +31,10 @@ Values set at the command line have highest priority, then those in the
 project configuration file, and finally there are the defaults. However,
 there are additional command line options which can alter this.
 
+.. note::
+
+    The home directory is **not** searched for ``setup.cfg``, ``tox.ini``,
+    or ``.flake8``
 
 Project Configuration
 ---------------------


### PR DESCRIPTION
Add a note about not looking for config files in the home directory.

Re: [PyCQA/flake8] Search for config files stops BEFORE home directory is searched (Issue #1808) Inbox

Anthony Sottile <notifications@github.com>
2:07 PM (52 minutes ago)
to PyCQA/flake8, me, Author

this is intentional -- flake8 configuration is not supported in the home directory -- please search the issue tracker there are several duplicates

—
Reply to this email directly, view it on GitHub, or unsubscribe. You are receiving this because you authored the thread.