### PR TITLE
feat: implement github format

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -52,6 +52,7 @@ flake8.extension =
     W = flake8.plugins.pycodestyle:pycodestyle_physical
 flake8.report =
     default = flake8.formatting.default:Default
+    github = flake8.formatting.default:GitHub
     pylint = flake8.formatting.default:Pylint
     quiet-filename = flake8.formatting.default:FilenameOnly
     quiet-nothing = flake8.formatting.default:Nothing

--- a/src/flake8/formatting/default.py
+++ b/src/flake8/formatting/default.py
@@ -78,6 +78,16 @@ class Pylint(SimpleFormatter):
     error_format = "%(path)s:%(row)d: [%(code)s] %(text)s"
 
 
+class GitHub(SimpleFormatter):
+    """GitHub formatter for Flake8."""
+
+    error_format = (
+        "::error title=Flake8 %(code)s,file=%(path)s,"
+        "line=%(row)d,col=%(col)d,endLine=%(row)d,endColumn=%(col)d"
+        "::%(code)s %(text)s"
+    )
+
+
 class FilenameOnly(SimpleFormatter):
     """Only print filenames, e.g., flake8 -q."""
 

--- a/tests/integration/test_main.py
+++ b/tests/integration/test_main.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import sys
 from unittest import mock
 
@@ -396,5 +397,8 @@ def test_format_option_help(capsys):
         cli.main(["--help"])
 
     out, err = capsys.readouterr()
-    assert "(default, pylint, quiet-filename, quiet-nothing)" in out
+    assert (
+        "(default, github, pylint, quiet-filename, quiet-nothing)"
+        in re.sub(re.compile(r"\n\s*"), "", out)  # noqa: E501
+    )
     assert err == ""


### PR DESCRIPTION
implement [GitHub annotation](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-error-message)

Motivation:

user can run flake8 --format=github and see github pr error annotation.