### PR TITLE
Update configuration.rst

### DIFF
--- a/docs/source/user/configuration.rst
+++ b/docs/source/user/configuration.rst
@@ -25,7 +25,8 @@ Configuration Locations
 =======================
 
 |Flake8| supports storing its configuration in your project in one of
-``setup.cfg``, ``tox.ini``, or ``.flake8``.
+``setup.cfg``, ``tox.ini``, or ``.flake8`` (in that order).
+If, say, ``setup.cfg`` is found, the rest of the files are not read.
 
 Values set at the command line have highest priority, then those in the
 project configuration file, and finally there are the defaults. However,


### PR DESCRIPTION
Clarify information about how the search for configuration files is done, particularly, state that only the first found file is read for configuration.