### PR TITLE
Exclude virtual env dirs by default

### DIFF
--- a/docs/source/user/options.rst
+++ b/docs/source/user/options.rst
@@ -234,7 +234,7 @@ Options and their Descriptions
 
     Provide a comma-separated list of glob patterns to exclude from checks.
 
-    This defaults to: ``.svn,CVS,.bzr,.hg,.git,__pycache__,.tox,.nox,.eggs,*.egg``
+    This defaults to: ``.svn,CVS,.bzr,.hg,.git,__pycache__,.tox,.nox,.eggs,*.egg,.env,env,.venv,venv``
 
     Example patterns:
 

--- a/src/flake8/defaults.py
+++ b/src/flake8/defaults.py
@@ -14,6 +14,10 @@ EXCLUDE = (
     ".nox",
     ".eggs",
     "*.egg",
+    ".env",
+    "env",
+    ".venv",
+    "venv",
 )
 IGNORE = ("E121", "E123", "E126", "E226", "E24", "E704", "W503", "W504")
 MAX_LINE_LENGTH = 79


### PR DESCRIPTION
Hi! ✋🏻 

There are some linters/formatters which automatically exclude/ignore names commonly used for virtual enviroment dirs, namely: `env`, `.env`, `venv`, `.venv`. I guess, it would be nice to have this feature in Flake8 as well.

Thanks for considering! 🤝