### PR TITLE
Document the no support for pyproject.toml

### DIFF
--- a/docs/source/user/configuration.rst
+++ b/docs/source/user/configuration.rst
@@ -25,7 +25,7 @@ Configuration Locations
 =======================
 
 |Flake8| supports storing its configuration in your project in one of
-``setup.cfg``, ``tox.ini``, or ``.flake8``.
+``setup.cfg``, ``tox.ini``, or ``.flake8``, but not ``pyproject.toml``.
 
 Values set at the command line have highest priority, then those in the
 project configuration file, and finally there are the defaults. However,


### PR DESCRIPTION
Maybe link to the plugin supporting it within the documentation? https://github.com/john-hen/Flake8-pyproject

This PR is because it took me a bit of time to figure out flake8 didn't have support for pyproject.toml as there's no reference to it in the documentation