### PR TITLE
Drop universal wheel option

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -51,9 +51,6 @@ flake8.report =
     quiet-filename = flake8.formatting.default:FilenameOnly
     quiet-nothing = flake8.formatting.default:Nothing
 
-[bdist_wheel]
-universal = 1
-
 [coverage:run]
 source =
     flake8


### PR DESCRIPTION
This drops the option for universal wheel builds.

From the official docs at https://wheel.readthedocs.io/en/stable/user_guide.html:

> If your project contains no C extensions and is expected to work on both Python 2 and 3, you will want to tell wheel to produce universal wheels by adding this to your `setup.cfg` file

Currently, the generated wheels for *flake8* seem to indicate that they still support Python 2 (`flake8-6.1.0-py2.py3-none-any.whl`, see https://pypi.org/project/flake8/#files), which is not the case.