### PR TITLE
Add a Dependabot config to auto-update GitHub action versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'monthly'
+    groups:
+      github-actions:
+        patterns:
+          - '*'


### PR DESCRIPTION
CI is currently throwing deprecation warnings due to out-of-date GitHub action versions ([recent example](https://github.com/PyCQA/flake8/actions/runs/7011588328)).

Rather than submit a PR to update the actions once, this PR configures Dependabot to submit PRs on a monthly basis to keep the action versions up-to-date. The updates will be batched together.

If this merges, you can expect Dependabot to immediately open a PR to update `actions/checkout@v2` to v4, and `actions/setup-python@v2` to v4.

Thanks for your work on Flake8!