### PR TITLE
Fix linting and test in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,6 +7,16 @@ on:
   pull_request:
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python }}
+      - run: python -mpip install --upgrade setuptools pip tox virtualenv
+      - run: tox -e linters
+
   main:
     strategy:
       matrix:

--- a/src/flake8/checker.py
+++ b/src/flake8/checker.py
@@ -70,7 +70,8 @@ def _mp_init(argv: Sequence[str]) -> None:
     signal.signal(signal.SIGINT, signal.SIG_IGN)
 
     try:
-        _mp_plugins, _mp_options  # for `fork` this'll already be set
+        # for `fork` these will already be set
+        _mp_plugins, _mp_options  # noqa: B018 ("useless Tuple")
     except NameError:
         plugins, options = parse_args(argv)
         _mp_plugins, _mp_options = plugins.checkers, options

--- a/tests/unit/plugins/reporter_test.py
+++ b/tests/unit/plugins/reporter_test.py
@@ -11,7 +11,7 @@ from flake8.plugins import reporter
 
 
 def _opts(**kwargs):
-    kwargs.setdefault("quiet", 0),
+    kwargs.setdefault("quiet", 0)
     kwargs.setdefault("color", "never")
     kwargs.setdefault("output_file", None)
     return argparse.Namespace(**kwargs)


### PR DESCRIPTION
I ran `tox -e linters` locally on `main` and discovered that flake8-bugbear was reporting B018 ("useless Tuple expression") errors for two files.

This PR introduces the following changes:

* Resolve the flake8-bugbear B018 errors
* Add a config to run the linters in CI

This should help reduce the possibility that lint errors slip into `main`.