### PR TITLE
Fix a workflow schema violation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,6 @@ name: main
 on:
   push:
     branches: [main]
-    tags:
   pull_request:
 
 jobs:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,3 +39,8 @@ repos:
     hooks:
     -   id: mypy
         exclude: ^(docs/|example-plugin/)
+-   repo: https://github.com/python-jsonschema/check-jsonschema
+    rev: 0.27.2
+    hooks:
+      - id: check-github-workflows
+      - id: check-readthedocs


### PR DESCRIPTION
The `main.yml` workflow contains a schema violation; its `tags` property is `null` (must an array with at least one item).

This PR introduces the following changes:

* Fix a schema violation in `main.yml`
* Add a pre-commit hook to validate workflow and the ReadTheDocs file for schema violations
