### PR TITLE
update plugins for sphinx-prompt-1.8.0

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -34,7 +34,7 @@ extensions = [
     "sphinx.ext.todo",
     "sphinx.ext.coverage",
     "sphinx.ext.viewcode",
-    "sphinx-prompt",
+    "sphinx_prompt",
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/source/requirements.txt
+++ b/docs/source/requirements.txt
@@ -1,4 +1,4 @@
 sphinx>=2.1.0,!=3.1.0
 sphinx-rtd-theme>=1.2.2
-sphinx-prompt>=1.5.0
+sphinx-prompt>=1.8.0
 docutils!=0.18


### PR DESCRIPTION
The sphinx-prompt plugin has renamed its package in 1.8.0 from erraneous `sphinx-prompt` name to `sphinx_prompt`.  Adjust the conf accordingly.