### PR TITLE
Add per-file-ignores mention in violations.rst

### DIFF
--- a/docs/source/user/violations.rst
+++ b/docs/source/user/violations.rst
@@ -136,6 +136,32 @@ the errors in that file will show up without having to modify our
 configuration. Both exist so we can choose which is better for us.
 
 
+Ignoring Violations for some Files
+-----------------------
+
+Sometimes, we might want to ignore some error codes (or class of error codes) for
+some part of our project (tests for example).
+We can do this using :option:`flake8 --per-file-ignores` from CLI:
+
+.. prompt:: bash
+
+ flake8 --per-file-ignores='project/test.py:F841 setup.py:E121'
+ flake8 --per-file-ignores='tests/*:F841 setup.py:E121'
+
+We can also specify it in config file:
+
+.. code-block:: ini
+
+     per-file-ignores =
+            project/test.py:F841
+            tests/*:F841
+            setup.py:E121
+            other_project/*:W9
+
+Syntax is similar with :option:`flake8 --exclude` for files
+and :option:`flake8 --ignore` for errors.
+
+
 
 Selecting Violations with Flake8
 ================================

--- a/docs/source/user/violations.rst
+++ b/docs/source/user/violations.rst
@@ -136,25 +136,31 @@ the errors in that file will show up without having to modify our
 configuration. Both exist so we can choose which is better for us.
 
 
-Ignoring Violations for some Files
------------------------
+Ignoring Violations in Specific Files
+-------------------------------------
 
-Sometimes, we might want to ignore some error codes (or class of error codes) for
-some part of our project (tests for example).
-We can do this using :option:`flake8 --per-file-ignores` from CLI:
+If we want to ignore one or more violation codes for certain files, you can 
+use the :option:`flake8 --per-file-ignores` on either the command-line
+or in your configuration file.
 
 .. prompt:: bash
 
- flake8 --per-file-ignores='project/test.py:F841 setup.py:E121'
- flake8 --per-file-ignores='tests/*:F841 setup.py:E121'
+   flake8 --per-file-ignores='project/test.py:F841 setup.py:E121'
+   flake8 --per-file-ignores='tests/*:F841,D setup.py:E121'
 
+.. note::
+
+   While most options in Flake8 use commas to separate values, this option allows
+   multiple violation codes to be specified per file with commas so to specify
+   multiple file mappings use spaces to delimit them.
+   
 We can also specify it in config file:
 
 .. code-block:: ini
 
      per-file-ignores =
             project/test.py:F841
-            tests/*:F841
+            tests/*:F841,D
             setup.py:E121
             other_project/*:W9
 

--- a/docs/source/user/violations.rst
+++ b/docs/source/user/violations.rst
@@ -139,7 +139,7 @@ configuration. Both exist so we can choose which is better for us.
 Ignoring Violations in Specific Files
 -------------------------------------
 
-If we want to ignore one or more violation codes for certain files, you can 
+If we want to ignore one or more violation codes for certain files, you can
 use the :option:`flake8 --per-file-ignores` on either the command-line
 or in your configuration file.
 
@@ -153,7 +153,7 @@ or in your configuration file.
    While most options in Flake8 use commas to separate values, this option allows
    multiple violation codes to be specified per file with commas so to specify
    multiple file mappings use spaces to delimit them.
-   
+
 We can also specify it in config file:
 
 .. code-block:: ini


### PR DESCRIPTION
There is no mention of "per-file-ignores" option in "Selecting and Ignoring Violations" section documentation, only in "Full Listing of Options and Their Descriptions".