### PR TITLE
Handle escaped braces in f-strings

### DIFF
--- a/src/flake8/processor.py
+++ b/src/flake8/processor.py
@@ -203,7 +203,13 @@ class FileProcessor:
             if token_type == tokenize.STRING:
                 text = mutate_string(text)
             elif token_type == FSTRING_MIDDLE:  # pragma: >=3.12 cover
-                text = "x" * len(text)
+                # A curly brace in an FSTRING_MIDDLE token must be an escaped
+                # curly brace. Both 'text' and 'end' will account for the
+                # escaped version of the token (i.e. a single brace) rather
+                # than the raw double brace version, so we must counteract this
+                brace_offset = text.count("{") + text.count("}")
+                text = "x" * (len(text) + brace_offset)
+                end = (end[0], end[1] + brace_offset)
             if previous_row:
                 (start_row, start_column) = start
                 if previous_row != start_row:


### PR DESCRIPTION
To use a curly brace in an f-string, you must escape it. For example:

```python
>>> k = 1
>>> f'{{{k}'
'{1'
```

Saving this as a script and running the 'tokenize' module highlights something odd around the counting of tokens:

```console
$ python -m tokenize test.py
0,0-0,0:            ENCODING       'utf-8'
1,0-1,1:            NAME           'k'
1,2-1,3:            OP             '='
1,4-1,5:            NUMBER         '1'
1,5-1,6:            NEWLINE        '\n'
2,0-2,2:            FSTRING_START  "f'"
2,2-2,3:            FSTRING_MIDDLE '{'     # <-- here...
2,4-2,5:            OP             '{'     # <-- and here
2,5-2,6:            NAME           'k'
2,6-2,7:            OP             '}'
2,7-2,8:            FSTRING_END    "'"
2,8-2,9:            NEWLINE        '\n'
3,0-3,0:            ENDMARKER      ''
```

The `FSTRING_MIDDLE` character we have is the escaped/post-parse single curly brace rather than the raw double curly brace, however, while our end index of this token accounts for the parsed form, the start index of the next token does not (put another way, it jumps from 3 -> 4). This triggers some existing, unrelated code that we need to bypass. Do just that.

Closes: #1948
