### PR TITLE
Easier plugin debugging by noting source filename of internal exceptions

### DIFF
--- a/src/flake8/checker.py
+++ b/src/flake8/checker.py
@@ -530,6 +530,12 @@ class FileChecker:
             row, column = self._extract_syntax_information(e)
             self.report(code, row, column, f"{type(e).__name__}: {e.args[0]}")
             return self.display_name, self.results, self.statistics
+        except BaseException as e:
+            try:
+                e.add_note(f"while checking {self.filename}")
+            except AttributeError:
+                pass  # PEP-678 .add_note() method is new in Python 3.11
+            raise
 
         logical_lines = self.processor.statistics["logical lines"]
         self.statistics["logical lines"] = logical_lines


### PR DESCRIPTION
I patched this in while trying to track down where in a rather large codebase https://github.com/python-trio/flake8-async/issues/322 was triggered, and then thought that it was useful enough and had so little downside that I should open this PR 🙂 