### PR TITLE
Plugin parameters inspection for Python 3.14

### DIFF
--- a/src/flake8/plugins/finder.py
+++ b/src/flake8/plugins/finder.py
@@ -12,7 +12,8 @@ from collections.abc import Iterable
 from typing import Any
 from typing import NamedTuple
 
-import annotationlib
+if sys.version_info >= (3, 14):
+    import annotationlib
 
 from flake8 import utils
 from flake8.defaults import VALID_CODE_PREFIX
@@ -279,7 +280,11 @@ def _parameters_for(func: Any) -> dict[str, bool]:
     parameters = {
         parameter.name: parameter.default is inspect.Parameter.empty
         for parameter in inspect.signature(
-            func, annotation_format=annotationlib.Format.STRING,
+            func, **(
+                {"annotation_format": annotationlib.Format.STRING}
+                if sys.version_info >= (3, 14)
+                else {}
+            ),
         ).parameters.values()
         if parameter.kind is inspect.Parameter.POSITIONAL_OR_KEYWORD
     }


### PR DESCRIPTION
With the release of Python 3.14, many runtime annotations can now be declared without strings. If they are evaluated then `NameError`s will occur.

Inspecting the callable signature of a plugin only requires the parameters' `name`s and `default`, so the annotations can be ignored and the inspection `annotation_format` can be set to `Format.STRING` (so long as `eval_str` is also `False` like it is by default).

See https://docs.python.org/3.14/library/inspect.html#inspect.signature & https://docs.python.org/3.14/library/annotationlib.html#annotationlib.Format.STRING