### PR TITLE
Document config handling for plugin option actions

### DIFF
--- a/docs/source/plugin-development/plugin-parameters.rst
+++ b/docs/source/plugin-development/plugin-parameters.rst
@@ -109,6 +109,13 @@ Each of these options works individually or can be combined. Let's look at a
 couple examples from |Flake8|. In each example, we will have
 ``option_manager`` which is an instance of |OptionManager|.
 
+.. note::
+
+    Values read from configuration files do not go through :mod:`argparse`
+    ``action`` handlers. If an option needs the same custom transformation for
+    both command-line and configuration values, prefer ``type=`` for that
+    transformation, or use the |Flake8|-specific normalizers documented above.
+
 .. code-block:: python
 
     option_manager.add_option(


### PR DESCRIPTION
﻿## Summary
- document that config-file values do not pass through argparse `action` handlers
- point plugin authors toward `type=` or Flake8's own normalizers when they need consistent CLI/config transformations

## Why
`parse_from_config=True` values are normalized by Flake8's config handling rather than by argparse. The current docs describe plugin option registration but do not call out that distinction, which can lead plugin authors to expect custom `action=` handlers to run for config values as well.

Closes #1770.

## Validation
- Not run locally
- Validation was limited to static inspection of the documentation change (`git diff --check`).