### PR TITLE
narrow run_check plugin exception handler in FileChecker

### DIFF
--- a/src/flake8/checker.py
+++ b/src/flake8/checker.py
@@ -340,7 +340,7 @@ class FileChecker:
             )
         try:
             return plugin.obj(**arguments, **params)
-        except Exception as all_exc:
+        except (AssertionError, AttributeError, NameError, SyntaxError, TypeError, ValueError) as all_exc:
             LOG.critical(
                 "Plugin %s raised an unexpected exception",
                 plugin.display_name,


### PR DESCRIPTION
FileChecker.run_check in src/flake8/checker.py catches bare 'except Exception as all_exc' around the call to plugin.obj(**arguments, **params), then logs at CRITICAL and re-raises as PluginExecutionFailed. The narrow set of failures that a user-written AST/logical/physical check can actually raise is:

- AssertionError: the plugin or one of its helpers did an explicit assert (rare in user code but well-defined)
- AttributeError: a typo in the plugin reading one of its arguments, or None.attr, or an AST node lookup that returned None
- NameError: undefined name in the plugin (unbound local after a refactor, shadowed import, etc.)
- SyntaxError: only possible if the plugin calls compile()/eval() on user data
- TypeError: wrong arg type, None passed to a list index, missing positional arg, plus keyword_arguments_for() returning a bad map
- ValueError: enum/argparse/int conversion failures, regex parse failures, invalid mode flags

Other Exception subclasses (e.g. OSError, RuntimeError, KeyError, IndexError, ZeroDivisionError, RecursionError, ImportError) are not in this set on the happy path; an OSError would indicate a flake8 host bug (file vanished between walk and read), and RecursionError/KeyError/IndexError/ZeroDivisionError are genuine programming bugs in the plugin that the existing 'Plugin X failed during execution' message already surfaces. By listing the specific exception types, the catch becomes self-documenting and KeyboardInterrupt/SystemExit still reach the asyncio/multiprocessing pool machinery that owns the future and call future.cancel() on a Ctrl-C, rather than being converted into a 'plugin failure' report and the spurious E999/E901 line that follows.