### PR TITLE
narrow _load_plugin exception handler in plugins.finder

### DIFF
--- a/src/flake8/plugins/finder.py
+++ b/src/flake8/plugins/finder.py
@@ -289,7 +289,7 @@ def _parameters_for(func: Any) -> dict[str, bool]:
 def _load_plugin(plugin: Plugin) -> LoadedPlugin:
     try:
         obj = plugin.entry_point.load()
-    except Exception as e:
+    except (AttributeError, ImportError, ModuleNotFoundError, ValueError) as e:
         raise FailedToLoadPlugin(plugin.package, e)
 
     if not callable(obj):


### PR DESCRIPTION
_load_plugin in src/flake8/plugins/finder.py catches bare 'except Exception as e' around plugin.entry_point.load() and rewraps the error as a FailedToLoadPlugin. The narrow set of failures that importlib.metadata.EntryPoint.load() can actually raise is:

- AttributeError: the entry-point's group is missing from the metadata, or the .value attribute is malformed
- ImportError: the module named in the entry-point spec does not import cleanly (SyntaxError in the user's plugin, missing __init__.py, or a circular import)
- ModuleNotFoundError: the package is not installed in the active environment, the entry point points to a module that has been removed, or a relative import failed
- ValueError: the entry-point spec string is malformed (not of the form 'package.module:attr'), the attrs don't exist in the package, or the resolver rejected the spec

Other Exception subclasses (e.g. OSError, TypeError, RuntimeError, KeyError, IndexError) are not on this path: OSError would indicate a flake8 host bug (e.g. permissions on the wheel cache), and TypeError/KeyError/IndexError are programming bugs in importlib that already raise from the resolver as one of the four above. Listing the specific exception types makes the catch self-documenting and lets KeyboardInterrupt/SystemExit propagate to the asyncio/multiprocessing pool machinery that owns the future, rather than being silently converted into a 'failed to load plugin' report that hides the user's Ctrl-C.