### PR TITLE
skip unknown config options in aggregate_options

### DIFF
--- a/src/flake8/options/aggregator.py
+++ b/src/flake8/options/aggregator.py
@@ -39,8 +39,25 @@ def aggregate_options(
         # If the config name is somehow different from the destination name,
         # fetch the destination name from our Option
         if not hasattr(default_values, config_name):
-            dest_val = manager.config_options_dict[config_name].dest
-            assert isinstance(dest_val, str)
+            try:
+                option = manager.config_options_dict[config_name]
+            except KeyError:
+                LOG.warning(
+                    'Config option "%s" is not registered with the active '
+                    "OptionManager; ignoring value %r",
+                    config_name,
+                    value,
+                )
+                continue
+            dest_val = option.dest
+            if not isinstance(dest_val, str):
+                LOG.warning(
+                    'Config option "%s" has no explicit "dest" attribute; '
+                    "ignoring value %r",
+                    config_name,
+                    value,
+                )
+                continue
             dest_name = dest_val
 
         LOG.debug(


### PR DESCRIPTION
aggregate_options in src/flake8/options/aggregator.py iterates the dict produced by config.parse_config, and for each name whose key is not an attribute on the default namespace, it looks up OptionManager.config_options_dict[config_name].dest to find the argparse destination name. Two paths can KeyError / AttributeError here:

1. The user has a stale tox.ini/setup.cfg/.flake8 that still references a config key from a plugin they have uninstalled. parse_config silently drops those names (the .get(option_name) returns None) but the iteration in aggregator only ever sees names that ARE registered, so the failure mode here is instead a plugin option that is registered in a *different* flake8 run but not the current one (e.g. CI vs. local, or an isolated run that hides extensions). The current code does 'dest_val = manager.config_options_dict[config_name].dest' which raises KeyError immediately and aborts the whole merge, so every config file the user has ever written is now a one-strike-and-you're-out failure.

2. The plugin registered the option without an explicit 'dest=' argument, so option.dest is still _ARG.NO (the sentinel Enum). The 'assert isinstance(dest_val, str)' that follows would fail and abort the merge.

The new code wraps both lookups in a KeyError + isinstance check, logs a warning, and continues to the next config entry. This matches the existing LOG.debug('Option X is not registered. Ignoring.') in config.parse_config, which already silently drops unknown names from config files.