### PR TITLE
Only honor noqa from comments

### DIFF
--- a/src/flake8/violation.py
+++ b/src/flake8/violation.py
@@ -2,8 +2,10 @@
 from __future__ import annotations
 
 import functools
+import io
 import linecache
 import logging
+import tokenize
 from re import Match
 from typing import NamedTuple
 
@@ -16,7 +18,20 @@ LOG = logging.getLogger(__name__)
 
 @functools.lru_cache(maxsize=512)
 def _find_noqa(physical_line: str) -> Match[str] | None:
-    return defaults.NOQA_INLINE_REGEXP.search(physical_line)
+    if defaults.NOQA_INLINE_REGEXP.search(physical_line) is None:
+        return None
+
+    try:
+        tokens = tokenize.generate_tokens(io.StringIO(physical_line).readline)
+        for token in tokens:
+            if token.type == tokenize.COMMENT:
+                match = defaults.NOQA_INLINE_REGEXP.search(token.string)
+                if match is not None:
+                    return match
+    except (SyntaxError, tokenize.TokenError):
+        return defaults.NOQA_INLINE_REGEXP.search(physical_line)
+
+    return None
 
 
 class Violation(NamedTuple):

--- a/tests/integration/test_main.py
+++ b/tests/integration/test_main.py
@@ -240,6 +240,19 @@ t.py:1:15: E711 comparison to None should be 'if cond is None:'
     assert out == expected
 
 
+def test_noqa_inside_string_literal_does_not_ignore_line(tmpdir, capsys):
+    """See https://github.com/pycqa/flake8/issues/1321."""
+    with tmpdir.as_cwd():
+        tmpdir.join("t.py").write("def f():\n    x = '# noqa'\n")
+        assert cli.main(["t.py"]) == 1
+
+    expected = """\
+t.py:2:5: F841 local variable 'x' is assigned to but never used
+"""
+    out, err = capsys.readouterr()
+    assert out == expected
+
+
 def test_specific_noqa_on_line_with_continuation(tmpdir, capsys):
     """See https://github.com/pycqa/flake8/issues/621."""
     t_py_src = '''\

--- a/tests/unit/test_violation.py
+++ b/tests/unit/test_violation.py
@@ -31,6 +31,9 @@ from flake8.violation import Violation
         ("ABC123", "a = 1  # noqa: ABC123", True),
         ("E111", "a = 1  # noqa: ABC123", False),
         ("ABC123", "a = 1  # noqa: ABC124", False),
+        ("E111", "a = '# noqa'", False),
+        ("E111", "a = '# noqa: E111'", False),
+        ("E111", "a = '# noqa'  # noqa: E111", True),
     ],
 )
 def test_is_inline_ignored(error_code, physical_line, expected_result):


### PR DESCRIPTION
## Summary

- Tokenize the physical line before accepting an inline `# noqa` match.
- Only treat `# noqa` as active when it comes from a Python comment token, not from a string literal.
- Keep the existing regex fallback for lines that cannot be tokenized.

Closes #1321.

## Tests

- `python -m tox -e py`
- `python -m tox -e flake8`
- `PYTHONPATH=src python -m pytest tests/unit/test_violation.py tests/integration/test_main.py -q`