### PR TITLE
Preserve legacy API options in parallel workers

### DIFF
--- a/src/flake8/checker.py
+++ b/src/flake8/checker.py
@@ -61,7 +61,9 @@ def _mp_prefork(
         _mp = None
 
 
-def _mp_init(argv: Sequence[str]) -> None:
+def _mp_init(
+    argv: Sequence[str], options: argparse.Namespace,
+) -> None:
     global _mp
 
     # Ensure correct signaling of ^C using multiprocessing.Pool.
@@ -69,7 +71,7 @@ def _mp_init(argv: Sequence[str]) -> None:
 
     # for `fork` this'll already be set
     if _mp is None:
-        plugins, options = parse_args(argv)
+        plugins, _ = parse_args(argv)
         _mp = plugins.checkers, options
 
 
@@ -192,7 +194,9 @@ class Manager:
     def run_parallel(self) -> None:
         """Run the checkers in parallel."""
         with _mp_prefork(self.plugins, self.options):
-            pool = _try_initialize_processpool(self.jobs, self.argv)
+            pool = _try_initialize_processpool(
+                self.jobs, self.argv, self.options,
+            )
 
         if pool is None:
             self.run_serial()
@@ -547,10 +551,13 @@ class FileChecker:
 def _try_initialize_processpool(
     job_count: int,
     argv: Sequence[str],
+    options: argparse.Namespace,
 ) -> multiprocessing.pool.Pool | None:
     """Return a new process pool instance if we are able to create one."""
     try:
-        return multiprocessing.Pool(job_count, _mp_init, initargs=(argv,))
+        return multiprocessing.Pool(
+            job_count, _mp_init, initargs=(argv, options),
+        )
     except OSError as err:
         if err.errno not in SERIAL_RETRY_ERRNOS:
             raise

--- a/tests/integration/test_api_legacy.py
+++ b/tests/integration/test_api_legacy.py
@@ -1,6 +1,10 @@
 """Integration tests for the legacy api."""
 from __future__ import annotations
 
+import subprocess
+import sys
+import textwrap
+
 from flake8.api import legacy
 
 
@@ -13,3 +17,38 @@ def test_legacy_api(tmpdir):
         style_guide = legacy.get_style_guide()
         report = style_guide.check_files([t_py.strpath])
         assert report.total_errors == 1
+
+
+def test_legacy_api_parallel_preserves_options(tmpdir):
+    script = tmpdir.join("check.py")
+    script.write(
+        textwrap.dedent(
+            """\
+            import multiprocessing
+            import tempfile
+            from pathlib import Path
+
+            from flake8.api import legacy
+
+
+            if __name__ == "__main__":
+                multiprocessing.set_start_method("spawn")
+                with tempfile.TemporaryDirectory() as tmp:
+                    root = Path(tmp)
+                    line = "x = " + repr("a" * 79) + "\\n"
+                    paths = []
+                    for name in ("one.py", "two.py"):
+                        path = root / name
+                        path.write_text(line)
+                        paths.append(str(path))
+
+                    style_guide = legacy.get_style_guide(
+                        color="never", max_line_length=88,
+                    )
+                    report = style_guide.check_files(paths)
+                    assert report.total_errors == 0
+            """,
+        ),
+    )
+
+    subprocess.run([sys.executable, script.strpath], check=True)

--- a/tests/integration/test_checker.py
+++ b/tests/integration/test_checker.py
@@ -288,10 +288,13 @@ def test_acquire_when_multiprocessing_pool_can_initialize():
 
     This simulates the behaviour on most common platforms.
     """
+    options = mock.sentinel.options
     with mock.patch("multiprocessing.Pool") as pool:
-        result = checker._try_initialize_processpool(2, [])
+        result = checker._try_initialize_processpool(2, [], options)
 
-    pool.assert_called_once_with(2, checker._mp_init, initargs=([],))
+    pool.assert_called_once_with(
+        2, checker._mp_init, initargs=([], options),
+    )
     assert result is pool.return_value
 
 
@@ -307,10 +310,13 @@ def test_acquire_when_multiprocessing_pool_can_not_initialize():
 
     https://github.com/python/cpython/blob/4e02981de0952f54bf87967f8e10d169d6946b40/Lib/multiprocessing/synchronize.py#L30-L33
     """
+    options = mock.sentinel.options
     with mock.patch("multiprocessing.Pool", side_effect=ImportError) as pool:
-        result = checker._try_initialize_processpool(2, [])
+        result = checker._try_initialize_processpool(2, [], options)
 
-    pool.assert_called_once_with(2, checker._mp_init, initargs=([],))
+    pool.assert_called_once_with(
+        2, checker._mp_init, initargs=([], options),
+    )
     assert result is None
 
 


### PR DESCRIPTION
Fixes #2011.

The legacy API applies keyword options after argument parsing. Spawn and forkserver workers reparsed `argv`, so multiple-file checks reverted to defaults such as a max line length of 79.

Pass the configured option namespace to worker initialization instead. The integration test forces a spawn context; it failed with two E501 errors before the fix and passes after it.
