### PR TITLE
fix: lint explicit CLI paths even when exclude matches basename

### DIFF
--- a/src/flake8/api/legacy.py
+++ b/src/flake8/api/legacy.py
@@ -10,7 +10,7 @@ import logging
 import os.path
 from typing import Any
 
-from flake8.discover_files import expand_paths
+from flake8 import utils
 from flake8.formatting import base as formatter
 from flake8.main import application as app
 from flake8.options.parse_args import parse_args
@@ -127,17 +127,18 @@ class StyleGuide:
         :returns:
             True if the filename is excluded, False otherwise.
         """
+        exclude = (*self.options.exclude, *self.options.extend_exclude)
 
         def excluded(path: str) -> bool:
-            paths = tuple(
-                expand_paths(
-                    paths=[path],
-                    stdin_display_name=self.options.stdin_display_name,
-                    filename_patterns=self.options.filename,
-                    exclude=self.options.exclude,
-                ),
+            # Query exclude patterns directly. Do not go through expand_paths:
+            # CLI discovery always lints explicit file arguments (#1074), but
+            # this API answers "does this path match exclude?", not "lint it?".
+            return utils.matches_filename(
+                path,
+                patterns=exclude,
+                log_message='"%(path)s" has %(whether)sbeen excluded',
+                logger=LOG,
             )
-            return not paths
 
         return excluded(filename) or (
             parent is not None and excluded(os.path.join(parent, filename))

--- a/src/flake8/discover_files.py
+++ b/src/flake8/discover_files.py
@@ -74,16 +74,24 @@ def expand_paths(
             logger=LOG,
         )
 
-    return (
-        filename
-        for path in paths
-        for filename in _filenames_from(path, predicate=is_excluded)
-        if (
-            # always lint `-`
-            filename == "-"
-            # always lint explicitly passed (even if not matching filter)
-            or path == filename
-            # otherwise, check the file against filtered patterns
-            or utils.fnmatch(filename, filename_patterns)
+    for path in paths:
+        # Explicit file arguments (not directories, not stdin) always lint,
+        # even when ``exclude`` matches the basename or a parent path.
+        # Directory discovery still honours exclude.  See issue #1074 and
+        # maintainer guidance that an explicit CLI path means "lint this".
+        if path != "-" and not os.path.isdir(path):
+            yield path
+            continue
+
+        yield from (
+            filename
+            for filename in _filenames_from(path, predicate=is_excluded)
+            if (
+                # always lint `-`
+                filename == "-"
+                # always lint explicitly passed (even if not matching filter)
+                or path == filename
+                # otherwise, check the file against filtered patterns
+                or utils.fnmatch(filename, filename_patterns)
+            )
         )
-    )

--- a/tests/unit/test_discover_files.py
+++ b/tests/unit/test_discover_files.py
@@ -164,3 +164,33 @@ def test_alternate_stdin_name_is_filtered():
 def test_filename_included_even_if_not_matching_include(tmp_path):
     some_file = str(tmp_path.joinpath("some/file"))
     assert _expand_paths(paths=(some_file,)) == {some_file}
+
+
+def test_explicit_file_not_excluded_by_basename_pattern(tmp_path):
+    """Issue #1074: basename exclude must not drop an explicit file path."""
+    module = tmp_path.joinpath("test", "module.py")
+    module.parent.mkdir()
+    module.write_text("import os\n", encoding="utf-8")
+    path = str(module)
+    assert _expand_paths(paths=(path,), exclude=["module.py"]) == {path}
+
+
+def test_explicit_file_not_excluded_by_parent_dir_pattern(tmp_path):
+    """Explicit files under an excluded directory still lint when named."""
+    module = tmp_path.joinpath("test", "module.py")
+    module.parent.mkdir()
+    module.write_text("import os\n", encoding="utf-8")
+    path = str(module)
+    assert _expand_paths(paths=(path,), exclude=["test"]) == {path}
+
+
+def test_directory_discovery_still_honors_exclude(tmp_path):
+    """Walking a tree still applies exclude patterns."""
+    module = tmp_path.joinpath("test", "module.py")
+    module.parent.mkdir()
+    module.write_text("import os\n", encoding="utf-8")
+    kept = tmp_path.joinpath("kept.py")
+    kept.write_text("import os\n", encoding="utf-8")
+    assert _expand_paths(paths=(str(tmp_path),), exclude=["test"]) == {
+        str(kept),
+    }


### PR DESCRIPTION
## Summary
When a path is listed explicitly on the command line, Flake8 should lint it even if `exclude` matches the basename or a parent directory. Directory discovery still honours exclude.

Maintainer guidance on #1074: an explicit CLI path means the user wants that file linted; the inconsistency was that basename excludes still dropped those files while directory excludes did not.

## Changes
- `expand_paths`: short-circuit non-directory / non-stdin paths so they always lint
- `StyleGuide.excluded` (legacy API): answer exclude matching via `matches_filename` instead of CLI discovery (so the API keeps answering "is this path excluded?")
- unit tests for basename + parent-dir exclude with an explicit path

## Test plan
- [x] `pytest tests/unit/test_discover_files.py tests/unit/test_legacy_api.py` (26 passed)
- [x] `pytest tests/unit/` (412 passed)
- [x] Manual: `flake8 test/module.py` with `exclude = module.py` and `exclude = test` both report F401; walking `.` with `exclude = test` stays clean

Closes #1074
